### PR TITLE
Update Regex to 1.5.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["regex", "human-readable"]
 categories = ["text-processing", "parser-implementations"]
 
 [dependencies]
-regex = "1"
+regex = "1.5.5"
 
 [dev-dependencies]
 stop-words = "0.6.2"


### PR DESCRIPTION
updates regex to 1.5.5 as per [security advisory](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)

(the second change was due to github formatting)