### PR TITLE
The rest of the roadmap features!

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ The eventual goal of this crate is to support all the syntax available in the [c
 
 ## Character Classes
 
-|      Implemented?        |   Expression   | Description                                                             |
-|:------------------------:|:--------------:|:------------------------------------------------------------------------|
-|  `or(&['x', 'y', 'z']) ` |    `[xyz]`     | A character class matching either x, y or z (union).                    |
-|  `nor(&['x', 'y', 'z'])` |    `[^xyz]`    | A character class matching any character except x, y and z.             |
-|`within_range('a'..='z')` |    `[a-z]`     | A character class matching any character in range a-z.                  |
-|`without_range('a'..='z')`|    `[^a-z]`    | A character class matching any character outside range a-z.             |
-|       See below          | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                      |                
-|  `non_alphanumeric()`    | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                             |               
-|         `or()`           |  `[x[^xyz]]`   | Nested/grouping character class (matching any character except y and z) |
-|      `and(&[])`/`&`      |  `[a-y&&xyz]`  | Intersection (a-y AND xyz = xy)                                         |             
-| `(or[1,2,3,4] & nor(3))` | `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)     |    
-|                          |   `[0-9--4]`   | Direct subtraction (matching 0-9 except 4)                              |             
-|                          |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only)                        |          
-|                          |    `[\[\]]`    | Escaping in character classes (matching `[` or `]`)                     |         
+|      Implemented?           |   Expression   | Description                                                             |
+|:---------------------------:|:--------------:|:------------------------------------------------------------------------|
+|  `or(&['x', 'y', 'z']) `    |    `[xyz]`     | A character class matching either x, y or z (union).                    |
+|  `nor(&['x', 'y', 'z'])`    |    `[^xyz]`    | A character class matching any character except x, y and z.             |
+|`within_range('a'..='z')`    |    `[a-z]`     | A character class matching any character in range a-z.                  |
+|`without_range('a'..='z')`   |    `[^a-z]`    | A character class matching any character outside range a-z.             |
+|       See below             | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                      |                
+|  `non_alphanumeric()`       | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                             |               
+|         `or()`              |  `[x[^xyz]]`   | Nested/grouping character class (matching any character except y and z) |
+|      `and(&[])`/`&`         |  `[a-y&&xyz]`  | Intersection (a-y AND xyz = xy)                                         |             
+| `(or[1,2,3,4] & nor(3))`    | `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)     |    
+|                             |   `[0-9--4]`   | Direct subtraction (matching 0-9 except 4)                              |             
+|                             |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only)                        |          
+|`or(&escape_all(&['[',']']))`|    `[\[\]]`    | Escaping in character classes (matching `[` or `]`)                     |         
 
 ## Perl Character Classes
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ The eventual goal of this crate is to support all the syntax available in the [c
 | `any()`                                     |         `.`         | any character except new line (includes new line with s flag) |
 | `digit()`                                   |        `\d`         | digit (`\p{Nd}`)                                              |
 | `non_digit()`                               |        `\D`         | not digit                                                     |
-| `unicode_category(UnicodeCategory)`         |        `\pN`        | Unicode non-script category                                   |
+| `unicode_category(UnicodeCategory)`         |        `\p{L}`      | Unicode non-script category                                   |
 | `unicode_script(UnicodeScript)`             |     `\p{Greek}`     | Unicode script category                                       |
-|                                             |        `\PN`        | Negated one-letter name Unicode character class               |
-|                                             |     `\P{Greek}`     | negated Unicode character class (general category or script)  |
+| `non_unicode_category(UnicodeCategory)`     |        `\P{L}`      | Negated one-letter name Unicode character class               |
+| `non_unicode_script(UnicodeCategory)`       |     `\P{Greek}`     | negated Unicode character class (general category or script)  |
 
 ## Character Classes
 

--- a/README.md
+++ b/README.md
@@ -49,19 +49,20 @@ The eventual goal of this crate is to support all the syntax available in the [c
 
 ## Character Classes
 
-|      Implemented?      |   Expression   | Description                                                             |
-|:----------------------:|:--------------:|:------------------------------------------------------------------------|
-| `or(&['x', 'y', 'z'])` |    `[xyz]`     | A character class matching either x, y or z (union).                    |
-|`nor(&['x', 'y', 'z'])` |    `[^xyz]`    | A character class matching any character except x, y and z.             |
-|                        |    `[a-z]`     | A character class matching any character in range a-z.                  |
-|       See below        | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                      |                
-|  `non_alphanumeric()`  | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                             |               
-|         `or()`         |  `[x[^xyz]]`   | Nested/grouping character class (matching any character except y and z) |
-|                        |  `[a-y&&xyz]`  | Intersection (matching x or y)                                          |             
-|                        | `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)     |    
-|                        |   `[0-9--4]`   | Direct subtraction (matching 0-9 except 4)                              |             
-|                        |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only)                        |          
-|                        |    `[\[\]]`    | Escaping in character classes (matching `[` or `]`)                     |         
+|      Implemented?        |   Expression   | Description                                                             |
+|:------------------------:|:--------------:|:------------------------------------------------------------------------|
+|  `or(&['x', 'y', 'z']) ` |    `[xyz]`     | A character class matching either x, y or z (union).                    |
+|  `nor(&['x', 'y', 'z'])` |    `[^xyz]`    | A character class matching any character except x, y and z.             |
+|`within_range('a'..='z')` |    `[a-z]`     | A character class matching any character in range a-z.                  |
+|`without_range('a'..='z')`|    `[^a-z]`    | A character class matching any character outside range a-z.             |
+|       See below          | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                      |                
+|  `non_alphanumeric()`    | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                             |               
+|         `or()`           |  `[x[^xyz]]`   | Nested/grouping character class (matching any character except y and z) |
+|                          |  `[a-y&&xyz]`  | Intersection (matching x or y)                                          |             
+|                          | `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)     |    
+|                          |   `[0-9--4]`   | Direct subtraction (matching 0-9 except 4)                              |             
+|                          |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only)                        |          
+|                          |    `[\[\]]`    | Escaping in character classes (matching `[` or `]`)                     |         
 
 ## Perl Character Classes
 

--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ The eventual goal of this crate is to support all the syntax available in the [c
 
 ## Single Character
 
-| Implemented?  | Expression  | Description                                                   |
-|:-------------:|:-----------:|:--------------------------------------------------------------| 
-|    `any()`    |     `.`     | any character except new line (includes new line with s flag) |
-|   `digit()`   |    `\d`     | digit (`\p{Nd}`)                                              |
-| `non_digit()` |    `\D`     | not digit                                                     |
-|               |    `\pN`    | One-letter name Unicode character class                       |
-|               | `\p{Greek}` | Unicode character class (general category or script)          |
-|               |    `\PN`    | Negated one-letter name Unicode character class               |
-|               | `\P{Greek}` | negated Unicode character class (general category or script)  |
+| Implemented?                                | Expression          | Description                                                   |
+|:-------------------------------------------:|:-------------------:|:--------------------------------------------------------------| 
+| `any()`                                     |         `.`         | any character except new line (includes new line with s flag) |
+| `digit()`                                   |        `\d`         | digit (`\p{Nd}`)                                              |
+| `non_digit()`                               |        `\D`         | not digit                                                     |
+| `unicode_category(UnicodeCategory)`         |        `\pN`        | Unicode non-script category                                   |
+| `unicode_script(UnicodeScript)`             |     `\p{Greek}`     | Unicode script category                                       |
+|                                             |        `\PN`        | Negated one-letter name Unicode character class               |
+|                                             |     `\P{Greek}`     | negated Unicode character class (general category or script)  |
 
 ## Character Classes
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The eventual goal of this crate is to support all the syntax available in the [c
 |      Implemented?      |   Expression   | Description                                                             |
 |:----------------------:|:--------------:|:------------------------------------------------------------------------|
 | `or(&['x', 'y', 'z'])` |    `[xyz]`     | A character class matching either x, y or z (union).                    |
-|                        |    `[^xyz]`    | A character class matching any character except x, y and z.             |
+|`nor(&['x', 'y', 'z'])` |    `[^xyz]`    | A character class matching any character except x, y and z.             |
 |                        |    `[a-z]`     | A character class matching any character in range a-z.                  |
 |       See below        | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                      |                
 |                        | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                             |               

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The eventual goal of this crate is to support all the syntax available in the [c
 |`nor(&['x', 'y', 'z'])` |    `[^xyz]`    | A character class matching any character except x, y and z.             |
 |                        |    `[a-z]`     | A character class matching any character in range a-z.                  |
 |       See below        | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                      |                
-|                        | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                             |               
+|  `non_alphanumeric()`  | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                             |               
 |         `or()`         |  `[x[^xyz]]`   | Nested/grouping character class (matching any character except y and z) |
 |                        |  `[a-y&&xyz]`  | Intersection (matching x or y)                                          |             
 |                        | `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)     |    

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ The eventual goal of this crate is to support all the syntax available in the [c
 
 ## Character Classes
 
-|      Implemented?           |   Expression   | Description                                                             |
-|:---------------------------:|:--------------:|:------------------------------------------------------------------------|
-|  `or(&['x', 'y', 'z']) `    |    `[xyz]`     | A character class matching either x, y or z (union).                    |
-|  `nor(&['x', 'y', 'z'])`    |    `[^xyz]`    | A character class matching any character except x, y and z.             |
-|`within_range('a'..='z')`    |    `[a-z]`     | A character class matching any character in range a-z.                  |
-|`without_range('a'..='z')`   |    `[^a-z]`    | A character class matching any character outside range a-z.             |
-|       See below             | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                      |                
-|  `non_alphanumeric()`       | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                             |               
-|         `or()`              |  `[x[^xyz]]`   | Nested/grouping character class (matching any character except y and z) |
-|      `and(&[])`/`&`         |  `[a-y&&xyz]`  | Intersection (a-y AND xyz = xy)                                         |             
-| `(or[1,2,3,4] & nor(3))`    | `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)     |    
-|                             |   `[0-9--4]`   | Direct subtraction (matching 0-9 except 4)                              |             
-|                             |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only)                        |          
-|`or(&escape_all(&['[',']']))`|    `[\[\]]`    | Escaping in character classes (matching `[` or `]`)                     |         
+|      Implemented?           |   Expression   | Description                                                                         |
+|:---------------------------:|:--------------:|:------------------------------------------------------------------------------------|
+|  `or(&['x', 'y', 'z']) `    |    `[xyz]`     | A character class matching either x, y or z (union).                                |
+|  `nor(&['x', 'y', 'z'])`    |    `[^xyz]`    | A character class matching any character except x, y and z.                         |
+|`within('a'..='z')`          |    `[a-z]`     | A character class matching any character in range a-z.                              |
+|`without('a'..='z')`         |    `[^a-z]`    | A character class matching any character outside range a-z.                         |
+|       See below             | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                                  |                
+|  `non_alphanumeric()`       | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                                         |               
+|         `or()`              |  `[x[^xyz]]`   | Nested/grouping character class (matching any character except y and z)             |
+|      `and(&[])`/`&`         |  `[a-y&&xyz]`  | Intersection (a-y AND xyz = xy)                                                     |             
+| `(or[1,2,3,4] & nor(3))`    | `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)                 |    
+|    `subtract(&[],&[])`      |   `[0-9--4]`   | Direct subtraction (matching 0-9 except 4). Use .collect::<Vec<char>> to use ranges.|             
+|                             |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only)                                    |          
+|`or(&escape_all(&['[',']']))`|    `[\[\]]`    | Escaping in character classes (matching `[` or `]`)                                 |         
 
 ## Perl Character Classes
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The eventual goal of this crate is to support all the syntax available in the [c
 |      `and(&[])`/`&`         |  `[a-y&&xyz]`  | Intersection (a-y AND xyz = xy)                                                     |             
 | `(or[1,2,3,4] & nor(3))`    | `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)                 |    
 |    `subtract(&[],&[])`      |   `[0-9--4]`   | Direct subtraction (matching 0-9 except 4). Use .collect::<Vec<char>> to use ranges.|             
-|                             |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only)                                    |          
+|      `xor(&[],&[])`         |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only). Requires .collect() for ranges.   |          
 |`or(&escape_all(&['[',']']))`|    `[\[\]]`    | Escaping in character classes (matching `[` or `]`)                                 |         
 
 ## Perl Character Classes
@@ -115,7 +115,7 @@ The eventual goal of this crate is to support all the syntax available in the [c
 | Implemented? | Expression | Description                     |
 |:------------:|:----------:|:--------------------------------|
 |      `+`     |  `xy`      | concatenation (x followed by y) |
-|    `or()`    |    `x\|y`                              | alternation (x or y, prefer x)  |
+|    `or()`    |    `x\|y`  | alternation (x or y, prefer x)  |
 
 ## Empty matches
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The eventual goal of this crate is to support all the syntax available in the [c
 |       See below          | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                      |                
 |  `non_alphanumeric()`    | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                             |               
 |         `or()`           |  `[x[^xyz]]`   | Nested/grouping character class (matching any character except y and z) |
-|                          |  `[a-y&&xyz]`  | Intersection (matching x or y)                                          |             
-|                          | `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)     |    
+|      `and(&[])`/`&`      |  `[a-y&&xyz]`  | Intersection (a-y AND xyz = xy)                                         |             
+| `(or[1,2,3,4] & nor(3))` | `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)     |    
 |                          |   `[0-9--4]`   | Direct subtraction (matching 0-9 except 4)                              |             
 |                          |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only)                        |          
 |                          |    `[\[\]]`    | Escaping in character classes (matching `[` or `]`)                     |         

--- a/examples/remove_stop_words_with_regex.rs
+++ b/examples/remove_stop_words_with_regex.rs
@@ -1,4 +1,4 @@
-use human_regex::{exactly, one_or_more, or, punctuation, whitespace, word_boundary};
+use human_regex::{escape_all, exactly, one_or_more, or, punctuation, whitespace, word_boundary};
 use stop_words::{get, LANGUAGE};
 
 fn main() {
@@ -19,8 +19,10 @@ fn main() {
         .replace_all(&*lowercase_doc, "");
 
     // Make a regex to match stopwords with trailing spaces and punctuation
-    let regex_for_stop_words =
-        word_boundary() + exactly(1, or(&words)) + word_boundary() + one_or_more(whitespace());
+    let regex_for_stop_words = word_boundary()
+        + exactly(1, or(&escape_all(&words)))
+        + word_boundary()
+        + one_or_more(whitespace());
 
     // Remove stop words
     let clean_text = regex_for_stop_words

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -6,53 +6,97 @@ use super::humanregex::HumanRegex;
 pub fn alphanumeric() -> HumanRegex {
     HumanRegex(r"[[:alnum:]]".to_string())
 }
+/// A function to match any non-alphanumeric character (`[^0-9A-Za-z]`)
+pub fn non_alphanumeric() -> HumanRegex {
+    HumanRegex(r"[[:^alnum:]]".to_string())
+}
 
 /// A function to match any alphabetic character (`[A-Za-z]`)
 pub fn alphabetic() -> HumanRegex {
     HumanRegex(r"[[:alpha:]]".to_string())
+}
+/// A function to match any non-alphabetic character (`[^A-Za-z]`)
+pub fn non_alphabetic() -> HumanRegex {
+    HumanRegex(r"[[:^alpha:]]".to_string())
 }
 
 /// A function to match any lowercase character (`[a-z]`)
 pub fn lowercase() -> HumanRegex {
     HumanRegex(r"[[:lower:]]".to_string())
 }
+/// A function to match any non-lowercase character (`[^a-z]`)
+pub fn non_lowercase() -> HumanRegex {
+    HumanRegex(r"[[:^lower:]]".to_string())
+}
 
-/// A function to match any lowercase character (`[A-Z]`)
+/// A function to match any uppercase character (`[A-Z]`)
 pub fn uppercase() -> HumanRegex {
     HumanRegex(r"[[:upper:]]".to_string())
+}
+/// A function to match any non-uppercase character (`[^A-Z]`)
+pub fn non_uppercase() -> HumanRegex {
+    HumanRegex(r"[[:^upper:]]".to_string())
 }
 
 /// A function to match any digit that would appear in a hexadecimal number (`[A-Fa-f0-9]`)
 pub fn hexdigit() -> HumanRegex {
     HumanRegex(r"[[:xdigit:]]".to_string())
 }
+/// A function to match any digit that wouldn't appear in a hexadecimal number (`[^A-Fa-f0-9]`)
+pub fn non_hexdigit() -> HumanRegex {
+    HumanRegex(r"[[:^xdigit:]]".to_string())
+}
 
 /// A function to match any ascii digit (`[\x00-\x7F]`)
 pub fn ascii() -> HumanRegex {
     HumanRegex(r"[[:ascii:]]".to_string())
+}
+/// A function to match any non-ascii digit (`[^\x00-\x7F]`)
+pub fn non_ascii() -> HumanRegex {
+    HumanRegex(r"[[:^ascii:]]".to_string())
 }
 
 /// A function to match blank characters (`[\t ]`)
 pub fn blank() -> HumanRegex {
     HumanRegex(r"[[:blank:]]".to_string())
 }
+/// A function to match non-blank characters (`[^\t ]`)
+pub fn non_blank() -> HumanRegex {
+    HumanRegex(r"[[:^blank:]]".to_string())
+}
 
 /// A function to match control characters (`[\x00-\x1F\x7F]`)
 pub fn control() -> HumanRegex {
     HumanRegex(r"[[:cntrl:]]".to_string())
+}
+/// A function to match non-control characters (`[^\x00-\x1F\x7F]`)
+pub fn non_control() -> HumanRegex {
+    HumanRegex(r"[[:^cntrl:]]".to_string())
 }
 
 /// A function to match graphical characters (`[!-~]`)
 pub fn graphical() -> HumanRegex {
     HumanRegex(r"[[:graph:]]".to_string())
 }
+/// A function to match non-graphical characters (`[^!-~]`)
+pub fn non_graphical() -> HumanRegex {
+    HumanRegex(r"[[:^graph:]]".to_string())
+}
 
 /// A function to match printable characters (`[ -~]`)
 pub fn printable() -> HumanRegex {
     HumanRegex(r"[[:print:]]".to_string())
 }
+/// A function to match unprintable characters (`[^ -~]`)
+pub fn non_printable() -> HumanRegex {
+    HumanRegex(r"[[:^print:]]".to_string())
+}
 
 /// A function to match punctuation (`[!-/:-@\[-`{-~]`)
 pub fn punctuation() -> HumanRegex {
     HumanRegex(r"[[:punct:]]".to_string())
+}
+/// A function to match non-punctuation (`[^!-/:-@\[-`{-~]`)
+pub fn non_punctuation() -> HumanRegex {
+    HumanRegex(r"[[:^punct:]]".to_string())
 }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -16,6 +16,24 @@ where
     HumanRegex(format!("(?:{})", escape(&*text.to_string())))
 }
 
+/// Escapes an entire list for use in something like an [or] or an [and] expression.
+///
+/// See the [cookbook] stop words example for an example of the utility of this function.
+/// ```
+/// use human_regex::direct::escape_all;
+/// let escaped_vec = escape_all(&vec!["et-al", "short-term", "full-scale"]);
+/// assert_eq!(escaped_vec, vec![r"et\-al", r"short\-term", r"full\-scale"]);
+///```
+pub fn escape_all<T>(options: &[T]) -> Vec<String>
+where
+    T: Into<String> + fmt::Display,
+{
+    options
+        .iter()
+        .map(|string| string.to_string().replace("-", r"\-"))
+        .collect()
+}
+
 /// This text is not escaped. You can use it, for instance, to add a regex string directly to the object.
 /// ```
 /// let regex_string = human_regex::nonescaped_text(r"^\d{2}$");

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -30,7 +30,15 @@ where
 {
     options
         .iter()
-        .map(|string| string.to_string().replace("-", r"\-"))
+        .map(|string| {
+            string
+                .to_string()
+                .replace("-", r"\-")
+                .replace("[", r"\[")
+                .replace("]", r"\]")
+                .replace("{", r"\{")
+                .replace("}", r"\}")
+        })
         .collect()
 }
 

--- a/src/logical.rs
+++ b/src/logical.rs
@@ -39,6 +39,29 @@ where
     HumanRegex(or(options).to_string().replacen("[", "[^", 1))
 }
 
+/// Xor on two bracketed expressions, also known as symmetric difference.
+///
+/// If you would like to use ranges, collect them into a Vec<T>.
+/// ```
+/// use human_regex::xor;
+/// let regex_string = xor(&('a'..='g').collect::<Vec<char>>(), &('b'..='h').collect::<Vec<char>>());
+/// println!("{}", regex_string);
+/// assert!(regex_string.to_regex().is_match("a"));
+/// assert!(regex_string.to_regex().is_match("h"));
+/// assert!(!regex_string.to_regex().is_match("d"));
+/// ```
+pub fn xor<T>(lhs: &[T], rhs: &[T]) -> HumanRegex
+where
+    T: Into<String> + fmt::Display,
+{
+    HumanRegex(format!("[{}~~{}]", or(lhs), or(rhs)))
+    // I really don't like this implementation, but it's the only
+    // "type safe" way to do it for now. I plan on completely overhauling
+    // the HumanRegex type system to include things like "BracketedExpression",
+    // which will implement Into<HumanRegex>, and that will be what's used as
+    // arguments here in the future.
+}
+
 /// A function for establishing an AND relationship between two or more possible matches
 /// ```
 /// use human_regex::{text, and, or, within};

--- a/src/logical.rs
+++ b/src/logical.rs
@@ -20,7 +20,23 @@ where
     for idx in 1..options.len() {
         regex_string = format!("{}|{}", regex_string, options[idx].to_string())
     }
-    HumanRegex(format!("(:?{})", regex_string))
+    HumanRegex(format!("[(:?{})]", regex_string))
+}
+
+/// Negated [or] relationship between two or more possible matches
+///```
+/// use human_regex::{text, logical::nor};
+/// let regex_string = text("gr") + nor(&[text("a"), text("e")]) + text("y");
+/// println!("{}", regex_string.to_string());
+/// assert!(!regex_string.to_regex().is_match("grey"));
+/// assert!(!regex_string.to_regex().is_match("gray"));
+/// assert!(regex_string.to_regex().is_match("groy"));
+/// ```
+pub fn nor<T>(options: &[T]) -> HumanRegex
+where
+    T: Into<String> + fmt::Display,
+{
+    HumanRegex(or(options).to_string().replacen("[", "[^", 1))
 }
 
 /// A function for establishing an AND relationship between two or more possible matches

--- a/src/logical.rs
+++ b/src/logical.rs
@@ -24,7 +24,7 @@ where
 }
 
 /// Negated [or] relationship between two or more possible matches
-///```
+/// ```
 /// use human_regex::{text, logical::nor};
 /// let regex_string = text("gr") + nor(&[text("a"), text("e")]) + text("y");
 /// println!("{}", regex_string.to_string());
@@ -40,13 +40,37 @@ where
 }
 
 /// A function for establishing an AND relationship between two or more possible matches
+/// ```
+/// use human_regex::{beginning, end, text, logical::{and,or}, shorthand::within_range};
+/// let regex_string = beginning() + and(&vec![within_range('a'..='y'),or(&['x','y','z'])]) + end();
+/// println!("{}", regex_string);
+/// assert!(regex_string.to_regex().is_match("x"));
+/// assert!(regex_string.to_regex().is_match("y"));
+/// assert!(!regex_string.to_regex().is_match("z"));
+/// ```
 pub fn and<T>(options: &[T]) -> HumanRegex
 where
     T: Into<String> + fmt::Display,
 {
     let mut regex_string = format!("{}", options[0].to_string());
     for idx in 1..options.len() {
-        regex_string = format!("{}&&{}", regex_string, options[idx].to_string())
+        regex_string = format!("[{}&&{}]", regex_string, options[idx].to_string())
     }
     HumanRegex(format!("(:?{})", regex_string))
+}
+/// Allows the use of `&` as a syntax sugar for [and]
+/// ```
+/// use human_regex::{beginning, end, text, logical::or, shorthand::within_range};
+/// let regex_string = beginning() + (within_range('a'..='y') & or(&['x','y','z'])) + end();
+/// println!("{}", regex_string);
+/// assert!(regex_string.to_regex().is_match("x"));
+/// assert!(regex_string.to_regex().is_match("y"));
+/// assert!(!regex_string.to_regex().is_match("z"));
+/// ```
+impl std::ops::BitAnd for HumanRegex {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        and(&vec![self, rhs])
+    }
 }

--- a/src/shorthand.rs
+++ b/src/shorthand.rs
@@ -69,6 +69,29 @@ pub fn non_whitespace() -> HumanRegex {
     HumanRegex(r"\S".to_string())
 }
 
+/// Matches anything within a range of characters
+///```
+/// use human_regex::{beginning, end, within_range};
+/// let regex_string = beginning() + within_range('a'..='d') + end();
+/// println!("{}", beginning());
+/// assert!(regex_string.to_regex().is_match("c"));
+/// assert!(!regex_string.to_regex().is_match("h"));
+///```
+pub fn within_range(range: std::ops::RangeInclusive<char>) -> HumanRegex {
+    HumanRegex(format!("[{}-{}]", range.start(), range.end()))
+}
+/// Matches anything outside of a range of characters
+///```
+/// use human_regex::{beginning, end, without_range};
+/// let regex_string = beginning() + without_range('a'..='d') + end();
+/// println!("{}", beginning());
+/// assert!(regex_string.to_regex().is_match("h"));
+/// assert!(!regex_string.to_regex().is_match("c"));
+///```
+pub fn without_range(range: std::ops::RangeInclusive<char>) -> HumanRegex {
+    HumanRegex(format!("[^{}-{}]", range.start(), range.end()))
+}
+
 /// An enum covering all Unicode character categories
 ///
 /// Used in the [unicode_category] function.

--- a/src/shorthand.rs
+++ b/src/shorthand.rs
@@ -166,6 +166,19 @@ pub fn unicode_category(category: UnicodeCategory) -> HumanRegex {
     })
 }
 
+/// A function for not matching Unicode character categories. For matching script categories see [non_unicode_script].
+/// ```
+/// use human_regex::{beginning, end, one_or_more, non_unicode_category, UnicodeCategory};
+/// let regex_string = beginning()
+///     + one_or_more(non_unicode_category(UnicodeCategory::CurrencySymbol))
+///     + end();
+/// assert!(regex_string.to_regex().is_match("normal words"));
+/// assert!(!regex_string.to_regex().is_match("$¥₹"));
+/// ```
+pub fn non_unicode_category(category: UnicodeCategory) -> HumanRegex {
+    HumanRegex(unicode_category(category).to_string().replace(r"\p", r"\P"))
+}
+
 /// An enum for covering all Unicode script categories
 ///
 /// Used in the [unicode_script] function
@@ -275,4 +288,17 @@ pub fn unicode_script(category: UnicodeScript) -> HumanRegex {
         UnicodeScript::Tibetan => r"\p{Tibetan}".to_string(),
         UnicodeScript::Yi => r"\p{Yi}".to_string(),
     })
+}
+
+/// A function for matching Unicode characters not belonging to a certain script category. For matching other categories see [non_unicode_category].
+/// ```
+/// use human_regex::{beginning, end, one_or_more, non_unicode_script, UnicodeScript};
+/// let regex_string = beginning()
+///     + one_or_more(non_unicode_script(UnicodeScript::Han))
+///     + end();
+/// assert!(regex_string.to_regex().is_match("latin text"));
+/// assert!(!regex_string.to_regex().is_match("蟹"));
+/// ```
+pub fn non_unicode_script(category: UnicodeScript) -> HumanRegex {
+    HumanRegex(unicode_script(category).to_string().replace(r"\p", r"\P"))
 }

--- a/src/shorthand.rs
+++ b/src/shorthand.rs
@@ -71,24 +71,24 @@ pub fn non_whitespace() -> HumanRegex {
 
 /// Matches anything within a range of characters
 ///```
-/// use human_regex::{beginning, end, within_range};
-/// let regex_string = beginning() + within_range('a'..='d') + end();
+/// use human_regex::{beginning, end, within};
+/// let regex_string = beginning() + within('a'..='d') + end();
 /// println!("{}", beginning());
 /// assert!(regex_string.to_regex().is_match("c"));
 /// assert!(!regex_string.to_regex().is_match("h"));
 ///```
-pub fn within_range(range: std::ops::RangeInclusive<char>) -> HumanRegex {
+pub fn within(range: std::ops::RangeInclusive<char>) -> HumanRegex {
     HumanRegex(format!("[{}-{}]", range.start(), range.end()))
 }
 /// Matches anything outside of a range of characters
 ///```
-/// use human_regex::{beginning, end, without_range};
-/// let regex_string = beginning() + without_range('a'..='d') + end();
+/// use human_regex::{beginning, end, without};
+/// let regex_string = beginning() + without('a'..='d') + end();
 /// println!("{}", beginning());
 /// assert!(regex_string.to_regex().is_match("h"));
 /// assert!(!regex_string.to_regex().is_match("c"));
 ///```
-pub fn without_range(range: std::ops::RangeInclusive<char>) -> HumanRegex {
+pub fn without(range: std::ops::RangeInclusive<char>) -> HumanRegex {
     HumanRegex(format!("[^{}-{}]", range.start(), range.end()))
 }
 

--- a/src/shorthand.rs
+++ b/src/shorthand.rs
@@ -68,3 +68,211 @@ pub fn whitespace() -> HumanRegex {
 pub fn non_whitespace() -> HumanRegex {
     HumanRegex(r"\S".to_string())
 }
+
+/// An enum covering all Unicode character categories
+///
+/// Used in the [unicode_category] function.
+#[allow(missing_docs)] // variants are self documenting
+pub enum UnicodeCategory {
+    Letter,
+    LowercaseLetter,
+    UppercaseLetter,
+    TitlecaseLetter,
+    CasedLetter,
+    ModifierLetter,
+    OtherLetter,
+    Mark,
+    NonSpacingMark,
+    SpaceCombiningMark,
+    EnclosingMark,
+    Separator,
+    SpaceSeparator,
+    LineSeparator,
+    ParagraphSeparator,
+    Symbol,
+    MathSymbol,
+    CurrencySymbol,
+    ModifierSymbol,
+    OtherSymbol,
+    Number,
+    DecimalDigitNumber,
+    LetterNumber,
+    OtherNumber,
+    Punctuation,
+    DashPunctuation,
+    OpenPunctuation,
+    ClosePunctuation,
+    InitialPunctuation,
+    FinalPunctuation,
+    ConnectorPunctuation,
+    OtherPunctuation,
+    Other,
+    Control,
+    Format,
+    PrivateUse,
+    Surrogate,
+    Unassigned,
+}
+
+/// A function for matching Unicode character categories. For matching script categories see [unicode_script].
+/// ```
+/// use human_regex::{beginning, end, one_or_more, unicode_category, UnicodeCategory};
+/// let regex_string = beginning()
+///     + one_or_more(unicode_category(UnicodeCategory::CurrencySymbol))
+///     + end();
+/// assert!(regex_string.to_regex().is_match("$¥₹"));
+/// assert!(!regex_string.to_regex().is_match("normal words"));
+/// ```
+pub fn unicode_category(category: UnicodeCategory) -> HumanRegex {
+    HumanRegex(match category {
+        UnicodeCategory::Letter => r"\p{Letter}".to_string(),
+        UnicodeCategory::LowercaseLetter => r"\p{Lowercase_Letter}".to_string(),
+        UnicodeCategory::UppercaseLetter => r"\p{Uppercase_Letter}".to_string(),
+        UnicodeCategory::TitlecaseLetter => r"\p{Titlecase_Letter}".to_string(),
+        UnicodeCategory::CasedLetter => r"\p{Cased_Letter}".to_string(),
+        UnicodeCategory::ModifierLetter => r"\p{Modifier_Letter}".to_string(),
+        UnicodeCategory::OtherLetter => r"\p{Other_Letter}".to_string(),
+        UnicodeCategory::Mark => r"\p{Mark}".to_string(),
+        UnicodeCategory::NonSpacingMark => r"\p{NonSpacing_Mark}".to_string(),
+        UnicodeCategory::SpaceCombiningMark => r"\p{SpaceCombining_Mark}".to_string(),
+        UnicodeCategory::EnclosingMark => r"\p{Enclosing_Mark}".to_string(),
+        UnicodeCategory::Separator => r"\p{Separator}".to_string(),
+        UnicodeCategory::SpaceSeparator => r"\p{Space_Separator}".to_string(),
+        UnicodeCategory::LineSeparator => r"\p{Line_Separator}".to_string(),
+        UnicodeCategory::ParagraphSeparator => r"\p{Paragraph_Separator}".to_string(),
+        UnicodeCategory::Symbol => r"\p{Symbol}".to_string(),
+        UnicodeCategory::MathSymbol => r"\p{Math_Symbol}".to_string(),
+        UnicodeCategory::CurrencySymbol => r"\p{Currency_Symbol}".to_string(),
+        UnicodeCategory::ModifierSymbol => r"\p{Modifier_Symbol}".to_string(),
+        UnicodeCategory::OtherSymbol => r"\p{Other_Symbol}".to_string(),
+        UnicodeCategory::Number => r"\p{Number}".to_string(),
+        UnicodeCategory::DecimalDigitNumber => r"\p{DecimalDigit_Number}".to_string(),
+        UnicodeCategory::LetterNumber => r"\p{Letter_Number}".to_string(),
+        UnicodeCategory::OtherNumber => r"\p{Other_Number}".to_string(),
+        UnicodeCategory::Punctuation => r"\p{Punctuation}".to_string(),
+        UnicodeCategory::DashPunctuation => r"\p{Dash_Punctuation}".to_string(),
+        UnicodeCategory::OpenPunctuation => r"\p{Open_Punctuation}".to_string(),
+        UnicodeCategory::ClosePunctuation => r"\p{Close_Punctuation}".to_string(),
+        UnicodeCategory::InitialPunctuation => r"\p{Initial_Punctuation}".to_string(),
+        UnicodeCategory::FinalPunctuation => r"\p{Final_Punctuation}".to_string(),
+        UnicodeCategory::ConnectorPunctuation => r"\p{Connector_Punctuation}".to_string(),
+        UnicodeCategory::OtherPunctuation => r"\p{Other_Punctuation}".to_string(),
+        UnicodeCategory::Other => r"\p{Other}".to_string(),
+        UnicodeCategory::Control => r"\p{Control}".to_string(),
+        UnicodeCategory::Format => r"\p{Format}".to_string(),
+        UnicodeCategory::PrivateUse => r"\p{Private_Use}".to_string(),
+        UnicodeCategory::Surrogate => r"\p{Surrogate}".to_string(),
+        UnicodeCategory::Unassigned => r"\p{Unassigned}".to_string(),
+    })
+}
+
+/// An enum for covering all Unicode script categories
+///
+/// Used in the [unicode_script] function
+#[allow(missing_docs)] // variants are self documenting
+pub enum UnicodeScript {
+    Common,
+    Arabic,
+    Armenian,
+    Bengali,
+    Bopomofo,
+    Braille,
+    Buhid,
+    CandianAboriginal,
+    Cherokee,
+    Cyrillic,
+    Devanagari,
+    Ethiopic,
+    Georgian,
+    Greek,
+    Gujarati,
+    Gurkmukhi,
+    Han,
+    Hangul,
+    Hanunoo,
+    Hebrew,
+    Hirigana,
+    Inherited,
+    Kannada,
+    Katakana,
+    Khmer,
+    Lao,
+    Latin,
+    Limbu,
+    Malayalam,
+    Mongolian,
+    Myanmar,
+    Ogham,
+    Oriya,
+    Runic,
+    Sinhala,
+    Syriac,
+    Tagalog,
+    Tagbanwa,
+    TaiLe,
+    Tamil,
+    Telugu,
+    Thaana,
+    Thai,
+    Tibetan,
+    Yi,
+}
+
+/// A function for matching Unicode characters belonging to a certain script category. For matching other categories see [unicode_category].
+/// ```
+/// use human_regex::{beginning, end, one_or_more, unicode_script, UnicodeScript};
+/// let regex_string = beginning()
+///     + one_or_more(unicode_script(UnicodeScript::Han))
+///     + end();
+/// assert!(regex_string.to_regex().is_match("蟹"));
+/// assert!(!regex_string.to_regex().is_match("latin text"));
+/// ```
+pub fn unicode_script(category: UnicodeScript) -> HumanRegex {
+    HumanRegex(match category {
+        UnicodeScript::Common => r"\p{Common}".to_string(),
+        UnicodeScript::Arabic => r"\p{Arabic}".to_string(),
+        UnicodeScript::Armenian => r"\p{Armenian}".to_string(),
+        UnicodeScript::Bengali => r"\p{Bengali}".to_string(),
+        UnicodeScript::Bopomofo => r"\p{Bopomofo}".to_string(),
+        UnicodeScript::Braille => r"\p{Braille}".to_string(),
+        UnicodeScript::Buhid => r"\p{Buhid}".to_string(),
+        UnicodeScript::CandianAboriginal => r"\p{CandianAboriginal}".to_string(),
+        UnicodeScript::Cherokee => r"\p{Cherokee}".to_string(),
+        UnicodeScript::Cyrillic => r"\p{Cyrillic}".to_string(),
+        UnicodeScript::Devanagari => r"\p{Devanagari}".to_string(),
+        UnicodeScript::Ethiopic => r"\p{Ethiopic}".to_string(),
+        UnicodeScript::Georgian => r"\p{Georgian}".to_string(),
+        UnicodeScript::Greek => r"\p{Greek}".to_string(),
+        UnicodeScript::Gujarati => r"\p{Gujarati}".to_string(),
+        UnicodeScript::Gurkmukhi => r"\p{Gurkmukhi}".to_string(),
+        UnicodeScript::Han => r"\p{Han}".to_string(),
+        UnicodeScript::Hangul => r"\p{Hangul}".to_string(),
+        UnicodeScript::Hanunoo => r"\p{Hanunoo}".to_string(),
+        UnicodeScript::Hebrew => r"\p{Hebrew}".to_string(),
+        UnicodeScript::Hirigana => r"\p{Hirigana}".to_string(),
+        UnicodeScript::Inherited => r"\p{Inherited}".to_string(),
+        UnicodeScript::Kannada => r"\p{Kannada}".to_string(),
+        UnicodeScript::Katakana => r"\p{Katakana}".to_string(),
+        UnicodeScript::Khmer => r"\p{Khmer}".to_string(),
+        UnicodeScript::Lao => r"\p{Lao}".to_string(),
+        UnicodeScript::Latin => r"\p{Latin}".to_string(),
+        UnicodeScript::Limbu => r"\p{Limbu}".to_string(),
+        UnicodeScript::Malayalam => r"\p{Malayalam}".to_string(),
+        UnicodeScript::Mongolian => r"\p{Mongolian}".to_string(),
+        UnicodeScript::Myanmar => r"\p{Myanmar}".to_string(),
+        UnicodeScript::Ogham => r"\p{Ogham}".to_string(),
+        UnicodeScript::Oriya => r"\p{Oriya}".to_string(),
+        UnicodeScript::Runic => r"\p{Runic}".to_string(),
+        UnicodeScript::Sinhala => r"\p{Sinhala}".to_string(),
+        UnicodeScript::Syriac => r"\p{Syriac}".to_string(),
+        UnicodeScript::Tagalog => r"\p{Tagalog}".to_string(),
+        UnicodeScript::Tagbanwa => r"\p{Tagbanwa}".to_string(),
+        UnicodeScript::TaiLe => r"\p{TaiLe}".to_string(),
+        UnicodeScript::Tamil => r"\p{Tamil}".to_string(),
+        UnicodeScript::Telugu => r"\p{Telugu}".to_string(),
+        UnicodeScript::Thaana => r"\p{Thaana}".to_string(),
+        UnicodeScript::Thai => r"\p{Thai}".to_string(),
+        UnicodeScript::Tibetan => r"\p{Tibetan}".to_string(),
+        UnicodeScript::Yi => r"\p{Yi}".to_string(),
+    })
+}


### PR DESCRIPTION
This branch contains documented and tested versions of all the remaining roadmap features left to implement. As noted in the comments of `xor` and `subtract`, I think our simple type system is holding us back currently. As of right now HumanRegex is essentially just a readable string templating system, which is fine, but it requires some jank to make sure the user cannot input invalid Rust RegEx, which is a shame. Now that these roadmap features are done, I think I could take on a project of refactoring the library to work with some new types implementing Into\<HumanRegex\> and some traits to go along with them. This way we could do really cool things like have a unified negation function. This would also allow us to clean up our generic system as mentioned [here](https://github.com/cmccomb/human_regex/issues/3). Let me know what you think of this idea.