### PR TITLE
The type refactor is here!

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ This crate currently supports the vast majority of syntax available in the [core
 
 ## Character Classes
 
-|      Implemented?           |   Expression   | Description                                                                         |
-|:---------------------------:|:--------------:|:------------------------------------------------------------------------------------|
-|  `or(&['x', 'y', 'z']) `    |    `[xyz]`     | A character class matching either x, y or z (union).                                |
-|  `nor(&['x', 'y', 'z'])`    |    `[^xyz]`    | A character class matching any character except x, y and z.                         |
-|`within('a'..='z')`          |    `[a-z]`     | A character class matching any character in range a-z.                              |
-|`without('a'..='z')`         |    `[^a-z]`    | A character class matching any character outside range a-z.                         |
-|       See below             | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                                  |                
-|  `non_alphanumeric()`       | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                                         |               
-|         `or()`              |  `[x[^xyz]]`   | Nested/grouping character class (matching any character except y and z)             |
-|      `and(&[])`/`&`         |  `[a-y&&xyz]`  | Intersection (a-y AND xyz = xy)                                                     |             
-| `(or[1,2,3,4] & nor(3))`    | `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)                 |    
-|    `subtract(&[],&[])`      |   `[0-9--4]`   | Direct subtraction (matching 0-9 except 4). Use .collect::<Vec<char>> to use ranges.|             
-|      `xor(&[],&[])`         |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only). Requires .collect() for ranges.   |          
-|`or(&escape_all(&['[',']']))`|    `[\[\]]`    | Escaping in character classes (matching `[` or `]`)                                 |         
+|      Implemented?            |   Expression   | Description                                                                         |
+|:----------------------------:|:--------------:|:------------------------------------------------------------------------------------|
+|`within_set(&['x', 'y', 'z'])`|    `[xyz]`     | A character class matching either x, y or z (union).                                |
+|`wthout_set(&['x', 'y', 'z'])`|    `[^xyz]`    | A character class matching any character except x, y and z.                         |
+|`within_range('a'..='z')`     |    `[a-z]`     | A character class matching any character in range a-z.                              |
+|`without_range('a'..='z')`    |    `[^a-z]`    | A character class matching any character outside range a-z.                         |
+|       See below              | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                                  |                
+|  `non_alphanumeric()`        | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                                         |               
+|`within_set()`                |  `[x[^xyz]]`   | Nested/grouping character class (matching any character except y and z)             |
+|      `and(lhs, rhs)`/`&`     |  `[a-y&&xyz]`  | Intersection (a-y AND xyz = xy)                                                     |             
+|`within_range()&without_set()`| `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)                 |    
+|    `subtract(lhs, rhs)`      |   `[0-9--4]`   | Direct subtraction (matching 0-9 except 4). Use .collect::<Vec<char>> to use ranges.|             
+|      `xor(lhs, rhs)`         |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only). Requires .collect() for ranges.   |          
+|`within_set(&escape_all())`   |    `[\[\]]`    | Escaping in character classes (matching `[` or `]`)                                 |         
 
 ## Perl Character Classes
 
@@ -110,12 +110,13 @@ This crate currently supports the vast majority of syntax available in the [core
 | `between(n, m, x).lazy()` | `x{n,m}?`  | at least n x and at most m x (ungreedy/lazy) |
 |  `at_least(n, x).lazy()`  |  `x{n,}?`  | at least n x (ungreedy/lazy)                 |
 
-## Composites
+## General Operations
 
-| Implemented? | Expression | Description                     |
-|:------------:|:----------:|:--------------------------------|
-|      `+`     |  `xy`      | concatenation (x followed by y) |
-|    `or()`    |    `x\|y`  | alternation (x or y, prefer x)  |
+| Implemented? | Expression                   | Description                                                         |
+|:------------:|:----------------------------:|:--------------------------------------------------------------------|
+|      `+`     |  `xy`                        | concatenation (x followed by y)                                     |
+|    `or()`    |    `x\|y`                    | alternation (x or y, prefer x)                                      |
+|      `!`     |`\d->\D`, `[xy]->[^xy]`, etc. | negation (works on any character class, or literal strings of text).|
 
 ## Empty matches
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ No more runtime regex panics or unexplained behavior, if it compiles, what can p
 
 |      Implemented?            |   Expression   | Description                                                                         |
 |:----------------------------:|:--------------:|:------------------------------------------------------------------------------------|
-|`within_set(&['x', 'y', 'z'])`|    `[xyz]`     | A character class matching either x, y or z (union).                                |
+|`within_set(&['x', 'y', 'z'])`|    `[xyz]`     | A character class matching either x, y or z.                                        |
 |`wthout_set(&['x', 'y', 'z'])`|    `[^xyz]`    | A character class matching any character except x, y and z.                         |
 |`within_range('a'..='z')`     |    `[a-z]`     | A character class matching any character in range a-z.                              |
 |`without_range('a'..='z')`    |    `[^a-z]`    | A character class matching any character outside range a-z.                         |
 |       See below              | `[[:alpha:]]`  | ASCII character class (`[A-Za-z]`)                                                  |                
 |  `non_alphanumeric()`        | `[[:^alpha:]]` | Negated ASCII character class (`[^A-Za-z]`)                                         |               
 |`within_set()`                |  `[x[^xyz]]`   | Nested/grouping character class (matching any character except y and z)             |
-|      `and(lhs, rhs)`/`&`     |  `[a-y&&xyz]`  | Intersection (a-y AND xyz = xy)                                                     |             
+|  `and(lhs, rhs)`/`lhs & rhs` |  `[a-y&&xyz]`  | Intersection (a-y AND xyz = xy)                                                     |             
 |`within_range()&without_set()`| `[0-9&&[^4]]`  | Subtraction using intersection and negation (matching 0-9 except 4)                 |    
 |    `subtract(lhs, rhs)`      |   `[0-9--4]`   | Direct subtraction (matching 0-9 except 4). Use .collect::<Vec<char>> to use ranges.|             
 |      `xor(lhs, rhs)`         |  `[a-g~~b-h]`  | Symmetric difference (matching `a` and `h` only). Requires .collect() for ranges.   |          

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ assert!(second_regex_string.to_regex().is_match("2014-01-01"));
 For a more extensive set of examples, please see [The Cookbook](crate::cookbook).
 
 # Features
-This crate currently supports the vast majority of syntax available in the [core Rust regex library](https://crates.io/crates/regex) through a human-readable API. 
-
+This crate currently supports the vast majority of syntax available in the [core Rust regex library](https://crates.io/crates/regex) through a human-readable API.   
+The type model that the API is built upon reflects the underlying syntax rules of regular languages/expressions, meaning you get the same instant compiler feedback you're use to in Rust while writing regex.
+No more runtime regex panics or unexplained behavior, if it compiles, what can plainly read is what you get.
 ## Single Character
 
 | Implemented?                                | Expression          | Description                                                   |

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -1,113 +1,114 @@
 //! Functions for ASCII character classes
 
-use super::humanregex::HumanRegex;
+use super::humanregex::*;
+use std::marker::PhantomData as pd;
 
 /// A function to match any alphanumeric character (`[0-9A-Za-z]`)
-pub fn alphanumeric() -> HumanRegex {
-    HumanRegex(r"[[:alnum:]]".to_string())
+pub fn alphanumeric() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:alnum:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match any non-alphanumeric character (`[^0-9A-Za-z]`)
-pub fn non_alphanumeric() -> HumanRegex {
-    HumanRegex(r"[[:^alnum:]]".to_string())
+pub fn non_alphanumeric() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:^alnum:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match any alphabetic character (`[A-Za-z]`)
-pub fn alphabetic() -> HumanRegex {
-    HumanRegex(r"[[:alpha:]]".to_string())
+pub fn alphabetic() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:alpha:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match any non-alphabetic character (`[^A-Za-z]`)
-pub fn non_alphabetic() -> HumanRegex {
-    HumanRegex(r"[[:^alpha:]]".to_string())
+pub fn non_alphabetic() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:^alpha:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match any lowercase character (`[a-z]`)
-pub fn lowercase() -> HumanRegex {
-    HumanRegex(r"[[:lower:]]".to_string())
+pub fn lowercase() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:lower:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match any non-lowercase character (`[^a-z]`)
-pub fn non_lowercase() -> HumanRegex {
-    HumanRegex(r"[[:^lower:]]".to_string())
+pub fn non_lowercase() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:^lower:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match any uppercase character (`[A-Z]`)
-pub fn uppercase() -> HumanRegex {
-    HumanRegex(r"[[:upper:]]".to_string())
+pub fn uppercase() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:upper:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match any non-uppercase character (`[^A-Z]`)
-pub fn non_uppercase() -> HumanRegex {
-    HumanRegex(r"[[:^upper:]]".to_string())
+pub fn non_uppercase() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:^upper:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match any digit that would appear in a hexadecimal number (`[A-Fa-f0-9]`)
-pub fn hexdigit() -> HumanRegex {
-    HumanRegex(r"[[:xdigit:]]".to_string())
+pub fn hexdigit() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:xdigit:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match any digit that wouldn't appear in a hexadecimal number (`[^A-Fa-f0-9]`)
-pub fn non_hexdigit() -> HumanRegex {
-    HumanRegex(r"[[:^xdigit:]]".to_string())
+pub fn non_hexdigit() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:^xdigit:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match any ascii digit (`[\x00-\x7F]`)
-pub fn ascii() -> HumanRegex {
-    HumanRegex(r"[[:ascii:]]".to_string())
+pub fn ascii() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:ascii:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match any non-ascii digit (`[^\x00-\x7F]`)
-pub fn non_ascii() -> HumanRegex {
-    HumanRegex(r"[[:^ascii:]]".to_string())
+pub fn non_ascii() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:^ascii:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match blank characters (`[\t ]`)
-pub fn blank() -> HumanRegex {
-    HumanRegex(r"[[:blank:]]".to_string())
+pub fn blank() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:blank:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match non-blank characters (`[^\t ]`)
-pub fn non_blank() -> HumanRegex {
-    HumanRegex(r"[[:^blank:]]".to_string())
+pub fn non_blank() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:^blank:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match control characters (`[\x00-\x1F\x7F]`)
-pub fn control() -> HumanRegex {
-    HumanRegex(r"[[:cntrl:]]".to_string())
+pub fn control() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:cntrl:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match non-control characters (`[^\x00-\x1F\x7F]`)
-pub fn non_control() -> HumanRegex {
-    HumanRegex(r"[[:^cntrl:]]".to_string())
+pub fn non_control() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:^cntrl:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match graphical characters (`[!-~]`)
-pub fn graphical() -> HumanRegex {
-    HumanRegex(r"[[:graph:]]".to_string())
+pub fn graphical() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:graph:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match non-graphical characters (`[^!-~]`)
-pub fn non_graphical() -> HumanRegex {
-    HumanRegex(r"[[:^graph:]]".to_string())
+pub fn non_graphical() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:^graph:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match printable characters (`[ -~]`)
-pub fn printable() -> HumanRegex {
-    HumanRegex(r"[[:print:]]".to_string())
+pub fn printable() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:print:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match unprintable characters (`[^ -~]`)
-pub fn non_printable() -> HumanRegex {
-    HumanRegex(r"[[:^print:]]".to_string())
+pub fn non_printable() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:^print:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match punctuation (`[!-/:-@\[-`{-~]`)
-pub fn punctuation() -> HumanRegex {
-    HumanRegex(r"[[:punct:]]".to_string())
+pub fn punctuation() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:punct:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }
 
 /// A function to match non-punctuation (`[^!-/:-@\[-`{-~]`)
-pub fn non_punctuation() -> HumanRegex {
-    HumanRegex(r"[[:^punct:]]".to_string())
+pub fn non_punctuation() -> HumanRegex<SymbolClass<Ascii>> {
+    HumanRegex(r"[[:^punct:]]".to_string(), pd::<SymbolClass<Ascii>>)
 }

--- a/src/capturing.rs
+++ b/src/capturing.rs
@@ -1,6 +1,7 @@
 //! Functions for capturing matches
 
-use super::humanregex::HumanRegex;
+use super::humanregex::*;
+use std::marker::PhantomData as pd;
 
 /// Add a numbered capturing group around an expression
 /// ```
@@ -18,8 +19,8 @@ use super::humanregex::HumanRegex;
 /// assert_eq!("14", caps.get(3).unwrap().as_str());
 /// ```
 
-pub fn capture(target: HumanRegex) -> HumanRegex {
-    HumanRegex(format!("({})", target))
+pub fn capture<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("({})", target), pd::<SymbolChain>)
 }
 
 /// Add a named capturing group around an expression
@@ -36,6 +37,6 @@ pub fn capture(target: HumanRegex) -> HumanRegex {
 /// assert_eq!("03", &caps["month"]);
 /// assert_eq!("14", &caps["day"]);
 /// ```
-pub fn named_capture(target: HumanRegex, name: &str) -> HumanRegex {
-    HumanRegex(format!("(?P<{}>{})", name, target))
+pub fn named_capture<T>(target: HumanRegex<T>, name: &str) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?P<{}>{})", name, target), pd::<SymbolChain>)
 }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -1,7 +1,8 @@
 //! Functions for directly matching text or adding known regex strings
 
-use super::humanregex::{fmt, HumanRegex};
+use super::humanregex::*;
 use regex::escape;
+use std::marker::PhantomData as pd;
 
 /// Add matching text to the regex string. Text that is added through this function is automatically escaped.
 /// ```
@@ -9,11 +10,14 @@ use regex::escape;
 /// assert!(regex_string.to_regex().is_match("asdf"));
 /// assert!(!regex_string.to_regex().is_match("asddf"));
 /// ```
-pub fn text<T>(text: T) -> HumanRegex
+pub fn text<T>(text: T) -> HumanRegex<LiteralSymbolChain>
 where
     T: Into<String> + fmt::Display,
 {
-    HumanRegex(format!("(?:{})", escape(&*text.to_string())))
+    HumanRegex(
+        format!("(?:{})", escape(&*text.to_string())),
+        pd::<LiteralSymbolChain>,
+    )
 }
 
 /// Escapes an entire list for use in something like an [or] or an [and] expression.
@@ -30,15 +34,7 @@ where
 {
     options
         .iter()
-        .map(|string| {
-            string
-                .to_string()
-                .replace("-", r"\-")
-                .replace("[", r"\[")
-                .replace("]", r"\]")
-                .replace("{", r"\{")
-                .replace("}", r"\}")
-        })
+        .map(|string| escape(&string.to_string()))
         .collect()
 }
 
@@ -49,6 +45,6 @@ where
 /// assert!(regex_string.to_regex().is_match("21"));
 /// assert!(!regex_string.to_regex().is_match("007"));
 /// ```
-pub fn nonescaped_text(text: &str) -> HumanRegex {
-    HumanRegex(format!("(?:{})", text.to_string()))
+pub fn nonescaped_text(text: &str) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?:{})", text.to_string()), pd::<SymbolChain>)
 }

--- a/src/emptymatches.rs
+++ b/src/emptymatches.rs
@@ -1,15 +1,16 @@
 //! Functions for the empty matches
 
-use super::humanregex::HumanRegex;
+use super::humanregex::*;
+use std::marker::PhantomData as pd;
 
 /// A function to match a word boundary
-pub fn word_boundary() -> HumanRegex {
-    HumanRegex(r"\b".to_string())
+pub fn word_boundary() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"\b".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// A function to match anything BUT a word boundary
-pub fn non_word_boundary() -> HumanRegex {
-    HumanRegex(r"\B".to_string())
+pub fn non_word_boundary() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"\B".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// A function to match the beginning of text (or start-of-line with multi-line mode)
@@ -19,8 +20,8 @@ pub fn non_word_boundary() -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("hexagon"));
 /// assert!(!regex_string.to_regex().is_match("chlorhexadine"));
 /// ```
-pub fn beginning() -> HumanRegex {
-    HumanRegex(r"^".to_string())
+pub fn beginning() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"^".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// A function to match the end of text (or end-of-line with multi-line mode)
@@ -30,8 +31,8 @@ pub fn beginning() -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("mend"));
 /// assert!(!regex_string.to_regex().is_match("endocrinologist"));
 /// ```
-pub fn end() -> HumanRegex {
-    HumanRegex(r"$".to_string())
+pub fn end() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"$".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// A function to match the beginning of text (even with multi-line mode enabled)
@@ -41,8 +42,8 @@ pub fn end() -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("hexagon"));
 /// assert!(!regex_string.to_regex().is_match("chlorhexadine"));
 /// ```
-pub fn beginning_of_text() -> HumanRegex {
-    HumanRegex(r"\A".to_string())
+pub fn beginning_of_text() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"\A".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// A function to match the end of text (even with multi-line mode enabled)
@@ -52,6 +53,6 @@ pub fn beginning_of_text() -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("mend"));
 /// assert!(!regex_string.to_regex().is_match("endocrinologist"));
 /// ```
-pub fn end_of_text() -> HumanRegex {
-    HumanRegex(r"\z".to_string())
+pub fn end_of_text() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"\z".to_string(), pd::<SymbolClass<Standard>>)
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -4,7 +4,8 @@
 // s     allow . to match \n
 // u     Unicode support (enabled by default)
 
-use super::humanregex::HumanRegex;
+use super::humanregex::*;
+use std::marker::PhantomData as pd;
 
 /// Makes all matches case insensitive, matching both upper and lowercase letters.
 /// ```
@@ -14,21 +15,21 @@ use super::humanregex::HumanRegex;
 /// assert!(regex_string.to_regex().is_match("spongebob"));
 /// assert!(!regex_string.to_regex().is_match("PaTrIcK"));
 /// ```
-pub fn case_insensitive(target: HumanRegex) -> HumanRegex {
-    HumanRegex(format!("(?i:{})", target))
+pub fn case_insensitive<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?i:{})", target), pd::<SymbolChain>)
 }
 
 /// Enables multiline mode, which will allow `beginning()` and `end()` to match the beginning and end of lines
-pub fn multi_line_mode(target: HumanRegex) -> HumanRegex {
-    HumanRegex(format!("(?m:{})", target))
+pub fn multi_line_mode<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?m:{})", target), pd::<SymbolChain>)
 }
 
 /// A function that will allow `.` to match newlines (`\n`)
-pub fn dot_matches_newline_too(target: HumanRegex) -> HumanRegex {
-    HumanRegex(format!("(?s:{})", target))
+pub fn dot_matches_newline_too<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?s:{})", target), pd::<SymbolChain>)
 }
 
 /// A function to disable unicode support
-pub fn disable_unicode(target: HumanRegex) -> HumanRegex {
-    HumanRegex(format!("(?-u:{})", target))
+pub fn disable_unicode<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?-u:{})", target), pd::<SymbolChain>)
 }

--- a/src/humanregex.rs
+++ b/src/humanregex.rs
@@ -1,22 +1,41 @@
 use regex::Regex;
 
 pub(crate) use std::fmt;
+use std::marker::PhantomData as pd;
 use std::ops::Add;
+
+/// Represents the state when [HumanRegex] is a wrapper for a standard single-character class (the kind that starts with a backslash followed by a letter)
+pub struct Standard;
+
+/// Represents the state when [HumanRegex] is a wrapper for a custom single-character class (the kind surrounded by one layer of square brackets)
+pub struct Custom;
+
+/// Represents the state when [HumanRegex] is a wrapper for a single-character ASCII class (the kind surrounded by colons and two layers of square brackets)
+pub struct Ascii;
+
+/// Represents the state when [HumanRegex] is a wrapper for any type of single-character class
+pub struct SymbolClass<T>(std::marker::PhantomData<T>);
+
+/// Represents the state when [HumanRegex] is a wrapper for a literal string of characters
+pub struct LiteralSymbolChain;
+
+/// Represents the state when [HumanRegex] is a wrapper for any arbitrary regular expression
+pub struct SymbolChain;
 
 /// The HumanRegex struct which maintains and updates the regex string.
 /// For most use cases it will never be necessary to instantiate this directly.
 #[derive(Debug)]
-pub struct HumanRegex(pub String);
+pub struct HumanRegex<T = SymbolChain>(pub String, pub std::marker::PhantomData<T>);
 
-impl HumanRegex {
+impl<T> HumanRegex<T> {
     /// Convert to a rust Regex
     pub fn to_regex(&self) -> Regex {
         Regex::new(&*self.0).unwrap()
     }
 
     /// Add a lazy modifier
-    pub fn lazy(&self) -> HumanRegex {
-        HumanRegex(format!("{}?", &*self.0))
+    pub fn lazy(&self) -> HumanRegex<T> {
+        HumanRegex(format!("{}?", &*self.0), pd::<T>)
     }
 }
 
@@ -25,24 +44,27 @@ impl HumanRegex {
 /// assert!(regex_string.to_regex().is_match("mccomb"));
 /// assert!(regex_string.to_regex().is_match("chrismccomb"));
 /// ```
-impl Add for HumanRegex {
-    type Output = Self;
+impl<T> Add for HumanRegex<T> {
+    type Output = HumanRegex<SymbolChain>;
 
     fn add(self, rhs: Self) -> Self::Output {
-        HumanRegex(format!("{}{}", self.to_string(), rhs.to_string()))
+        HumanRegex(
+            format!("{}{}", self.to_string(), rhs.to_string()),
+            pd::<SymbolChain>,
+        )
     }
 }
 
 // Implement the Display trait for HumanRegex
-impl fmt::Display for HumanRegex {
+impl<T> fmt::Display for HumanRegex<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
 // Make it possible to create strings from HumanRegex
-impl From<HumanRegex> for String {
-    fn from(hr: HumanRegex) -> Self {
+impl<T> From<HumanRegex<T>> for String {
+    fn from(hr: HumanRegex<T>) -> Self {
         hr.to_string()
     }
 }

--- a/src/humanregex.rs
+++ b/src/humanregex.rs
@@ -39,15 +39,17 @@ impl<T> HumanRegex<T> {
     }
 }
 
+/// One of the three fundemental operations on Regular Languages, concatenation!
 /// ```
-/// let regex_string = human_regex::zero_or_one("chris") + human_regex::text("mccomb");
+/// use human_regex::{zero_or_one, text};
+/// let regex_string = zero_or_one(text("chris")) + text("mccomb");
 /// assert!(regex_string.to_regex().is_match("mccomb"));
 /// assert!(regex_string.to_regex().is_match("chrismccomb"));
 /// ```
-impl<T> Add for HumanRegex<T> {
+impl<T, U> Add<HumanRegex<U>> for HumanRegex<T> {
     type Output = HumanRegex<SymbolChain>;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, rhs: HumanRegex<U>) -> Self::Output {
         HumanRegex(
             format!("{}{}", self.to_string(), rhs.to_string()),
             pd::<SymbolChain>,

--- a/src/logical.rs
+++ b/src/logical.rs
@@ -114,7 +114,7 @@ impl std::ops::Not for HumanRegex<SymbolClass<Standard>> {
             .to_string()
             .chars()
             .nth(1)
-            .expect("Should always be 2 characters in SymbolClass<Standard>")
+            .expect("All classes shorter than 2 characters filtered above")
             .is_lowercase()
         {
             HumanRegex(

--- a/src/logical.rs
+++ b/src/logical.rs
@@ -107,6 +107,9 @@ impl std::ops::Not for HumanRegex<SymbolClass<Standard>> {
     type Output = Self;
 
     fn not(self) -> Self::Output {
+        if self.to_string().len() < 2 {
+            return self;
+        }
         if self
             .to_string()
             .chars()

--- a/src/logical.rs
+++ b/src/logical.rs
@@ -1,7 +1,7 @@
 //! Functions for performing logical operations
 
-use super::humanregex::HumanRegex;
-use std::fmt;
+use super::humanregex::*;
+use std::marker::PhantomData as pd;
 
 /// A function for establishing an OR relationship between two or more possible matches
 /// ```
@@ -12,7 +12,7 @@ use std::fmt;
 /// assert!(regex_string.to_regex().is_match("gray"));
 /// assert!(!regex_string.to_regex().is_match("graey"));
 /// ```
-pub fn or<T>(options: &[T]) -> HumanRegex
+pub fn or<T>(options: &[T]) -> HumanRegex<SymbolChain>
 where
     T: Into<String> + fmt::Display,
 {
@@ -20,28 +20,11 @@ where
     for idx in 1..options.len() {
         regex_string = format!("{}|{}", regex_string, options[idx].to_string())
     }
-    HumanRegex(format!("(:?{})", regex_string))
+    HumanRegex(format!("(:?{})", regex_string), pd::<SymbolChain>)
 }
 
-/// Negated [or] relationship between two or more possible matches
-/// ```
-/// use human_regex::{text, nor};
-/// let regex_string = text("gr") + nor(&[text("a"), text("e")]) + text("y");
-/// println!("{}", regex_string.to_string());
-/// assert!(!regex_string.to_regex().is_match("grey"));
-/// assert!(!regex_string.to_regex().is_match("gray"));
-/// assert!(regex_string.to_regex().is_match("groy"));
-/// ```
-pub fn nor<T>(options: &[T]) -> HumanRegex
-where
-    T: Into<String> + fmt::Display,
-{
-    HumanRegex(format!("[{}]", or(options).to_string()).replacen("[", "[^", 1))
-}
-
-/// Xor on two bracketed expressions, also known as symmetric difference.
+/// Xor on two [SymbolClass]es, also known as symmetric difference.
 ///
-/// If you would like to use ranges, collect them into a Vec<T>.
 /// ```
 /// use human_regex::xor;
 /// let regex_string = xor(&('a'..='g').collect::<Vec<char>>(), &('b'..='h').collect::<Vec<char>>());
@@ -50,16 +33,14 @@ where
 /// assert!(regex_string.to_regex().is_match("h"));
 /// assert!(!regex_string.to_regex().is_match("d"));
 /// ```
-pub fn xor<T>(lhs: &[T], rhs: &[T]) -> HumanRegex
-where
-    T: Into<String> + fmt::Display,
-{
-    HumanRegex(format!("[{}~~{}]", or(lhs), or(rhs)))
-    // I really don't like this implementation, but it's the only
-    // "type safe" way to do it for now. I plan on completely overhauling
-    // the HumanRegex type system to include things like "BracketedExpression",
-    // which will implement Into<HumanRegex>, and that will be what's used as
-    // arguments here in the future.
+pub fn xor<T, U>(
+    lhs: HumanRegex<SymbolClass<T>>,
+    rhs: HumanRegex<SymbolClass<U>>,
+) -> HumanRegex<SymbolClass<Custom>> {
+    HumanRegex(
+        format!("[{}~~{}]", lhs.to_string(), rhs.to_string()),
+        pd::<SymbolClass<Custom>>,
+    )
 }
 
 /// A function for establishing an AND relationship between two or more possible matches
@@ -71,15 +52,11 @@ where
 /// assert!(regex_string.to_regex().is_match("y"));
 /// assert!(!regex_string.to_regex().is_match("z"));
 /// ```
-pub fn and<T>(options: &[T]) -> HumanRegex
-where
-    T: Into<String> + fmt::Display,
-{
-    let mut regex_string = format!("{}", options[0].to_string());
-    for idx in 1..options.len() {
-        regex_string = format!("[{}&&{}]", regex_string, options[idx].to_string())
-    }
-    HumanRegex(format!("(:?{})", regex_string))
+pub fn and<T, U>(
+    lhs: HumanRegex<SymbolClass<T>>,
+    rhs: HumanRegex<SymbolClass<U>>,
+) -> HumanRegex<SymbolClass<Custom>> {
+    lhs & rhs
 }
 
 /// Allows the use of `&` as a syntax sugar for [and]
@@ -91,11 +68,14 @@ where
 /// assert!(regex_string.to_regex().is_match("y"));
 /// assert!(!regex_string.to_regex().is_match("z"));
 /// ```
-impl std::ops::BitAnd for HumanRegex {
-    type Output = Self;
+impl<T, U> std::ops::BitAnd<HumanRegex<SymbolClass<U>>> for HumanRegex<SymbolClass<T>> {
+    type Output = HumanRegex<SymbolClass<Custom>>;
 
-    fn bitand(self, rhs: Self) -> Self::Output {
-        and(&vec![self, rhs])
+    fn bitand(self, rhs: HumanRegex<SymbolClass<U>>) -> Self::Output {
+        HumanRegex(
+            format!("[{}&&{}]", self.to_string(), rhs.to_string()),
+            pd::<SymbolClass<Custom>>,
+        )
     }
 }
 
@@ -110,14 +90,96 @@ impl std::ops::BitAnd for HumanRegex {
 /// assert!(regex_string.to_regex().is_match("9"));
 /// assert!(!regex_string.to_regex().is_match("4"));
 /// ```
-pub fn subtract<T>(from: &[T], subtract: &[T]) -> HumanRegex
-where
-    T: Into<String> + fmt::Display,
-{
-    HumanRegex(format!("[{}--{}]", or(from), or(subtract)))
-    // I really don't like this implementation, but it's the only
-    // "type safe" way to do it for now. I plan on completely overhauling
-    // the HumanRegex type system to include things like "BracketedExpression",
-    // which will implement Into<HumanRegex>, and that will be what's used as
-    // arguments here in the future.
+pub fn subtract<T, U>(
+    from: HumanRegex<SymbolClass<T>>,
+    subtract: HumanRegex<SymbolClass<U>>,
+) -> HumanRegex<SymbolClass<Custom>> {
+    HumanRegex(
+        format!("[{}--{}]", from.to_string(), subtract.to_string()),
+        pd::<SymbolClass<Custom>>,
+    )
+}
+
+impl std::ops::Not for HumanRegex<SymbolClass<Standard>> {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        HumanRegex(
+            self.to_string()
+                .replace(r"\d", r"\D")
+                .replace(r"\d", r"\D")
+                .replace(r"\d", r"\D")
+                .replace(r"\d", r"\D")
+                .replace(r"\d", r"\D")
+                .replace(r"\d", r"\D")
+                .replace(r"\d", r"\D")
+                .replace(r"\d", r"\D")
+                .replace(r"\d", r"\D")
+                .replace(r"\d", r"\D"),
+            pd::<SymbolClass<Standard>>,
+        )
+    }
+}
+
+impl std::ops::Not for HumanRegex<SymbolClass<Custom>> {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        if self
+            .to_string()
+            .chars()
+            .nth(0)
+            .expect("Should always be at least 1 character")
+            != '^'
+        {
+            HumanRegex(
+                self.to_string().replace("[", "[^"),
+                pd::<SymbolClass<Custom>>,
+            )
+        } else {
+            HumanRegex(
+                self.to_string().replace("[^", "["),
+                pd::<SymbolClass<Custom>>,
+            )
+        }
+    }
+}
+
+impl std::ops::Not for HumanRegex<SymbolClass<Ascii>> {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        if self
+            .to_string()
+            .chars()
+            .nth(3)
+            .expect("Should always be at least 4 characters in SymbolClass<Ascii>")
+            != '^'
+        {
+            HumanRegex(
+                self.to_string().replace("[[:", "[[:^"),
+                pd::<SymbolClass<Ascii>>,
+            )
+        } else {
+            HumanRegex(
+                self.to_string().replace("[[:^", "[[:"),
+                pd::<SymbolClass<Ascii>>,
+            )
+        }
+    }
+}
+
+impl std::ops::Not for HumanRegex<LiteralSymbolChain> {
+    type Output = HumanRegex<SymbolChain>;
+
+    fn not(self) -> Self::Output {
+        HumanRegex(
+            self.to_string()
+                .chars()
+                .into_iter()
+                .map(|chr| format!("[^{}]", chr))
+                .collect::<String>(),
+            pd::<SymbolChain>,
+        )
+    }
 }

--- a/src/repetitions.rs
+++ b/src/repetitions.rs
@@ -5,7 +5,8 @@ use std::marker::PhantomData as pd;
 
 /// Match at least _n_ of a certain target
 /// ```
-/// let regex_string = human_regex::at_least(3, "a");
+/// use human_regex::{at_least, text};
+/// let regex_string = at_least(3, text("a"));
 /// assert!(regex_string.to_regex().is_match("aaaa"));
 /// assert!(!regex_string.to_regex().is_match("aa"));
 /// ```
@@ -15,7 +16,8 @@ pub fn at_least<T>(n: u8, target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
 
 /// Match at least _n_ and at most _m_ of a certain target
 /// ```
-/// let regex_string = human_regex::between(3, 5, "a");
+/// use human_regex::{between, text};
+/// let regex_string = between(3, 5, text("a"));
 /// assert!(regex_string.to_regex().is_match("aaaa"));
 /// assert!(!regex_string.to_regex().is_match("aa"));
 /// ```
@@ -25,7 +27,8 @@ pub fn between<T>(n: u8, m: u8, target: HumanRegex<T>) -> HumanRegex<SymbolChain
 
 /// Match one or more of a certain target
 /// ```
-/// let regex_string = human_regex::one_or_more("a");
+/// use human_regex::{one_or_more, text};
+/// let regex_string = one_or_more(text("a"));
 /// assert!(regex_string.to_regex().is_match("aaaa"));
 /// assert!(!regex_string.to_regex().is_match("bb"));
 /// ```
@@ -35,8 +38,10 @@ pub fn one_or_more<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
 
 /// Match zero or more of a certain target
 /// ```
-/// let regex_string = human_regex::zero_or_more("a");
+/// use human_regex::{zero_or_more, text};
+/// let regex_string = zero_or_more(text("a"));
 /// assert!(regex_string.to_regex().is_match("a"));
+/// assert!(regex_string.to_regex().is_match("aaaaa"));
 /// assert!(regex_string.to_regex().is_match("bb"));
 /// ```
 pub fn zero_or_more<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
@@ -45,7 +50,8 @@ pub fn zero_or_more<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
 
 /// Match zero or one of a certain target
 /// ```
-/// let regex_string = human_regex::zero_or_one("a");
+/// use human_regex::{zero_or_one, text};
+/// let regex_string = zero_or_one(text("a"));
 /// assert!(regex_string.to_regex().is_match("a"));
 /// assert!(regex_string.to_regex().is_match("bb"));
 /// ```
@@ -55,7 +61,8 @@ pub fn zero_or_one<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
 
 /// Match exactly _n_ of a certain target
 /// ```
-/// let regex_string = human_regex::exactly(5, "a");
+/// use human_regex::{exactly, text};
+/// let regex_string = exactly(5, text("a"));
 /// assert!(regex_string.to_regex().is_match("aaaaa"));
 /// assert!(!regex_string.to_regex().is_match("aaa"));
 /// ```

--- a/src/repetitions.rs
+++ b/src/repetitions.rs
@@ -1,6 +1,7 @@
 //! Functions for matching repetitions
 
-use super::humanregex::{fmt, HumanRegex};
+use super::humanregex::*;
+use std::marker::PhantomData as pd;
 
 /// Match at least _n_ of a certain target
 /// ```
@@ -8,11 +9,8 @@ use super::humanregex::{fmt, HumanRegex};
 /// assert!(regex_string.to_regex().is_match("aaaa"));
 /// assert!(!regex_string.to_regex().is_match("aa"));
 /// ```
-pub fn at_least<T>(n: u8, target: T) -> HumanRegex
-where
-    T: Into<String> + fmt::Display,
-{
-    HumanRegex(format!("(?:{}){{{},}}", target, n))
+pub fn at_least<T>(n: u8, target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?:{}){{{},}}", target, n), pd::<SymbolChain>)
 }
 
 /// Match at least _n_ and at most _m_ of a certain target
@@ -21,11 +19,8 @@ where
 /// assert!(regex_string.to_regex().is_match("aaaa"));
 /// assert!(!regex_string.to_regex().is_match("aa"));
 /// ```
-pub fn between<T>(n: u8, m: u8, target: T) -> HumanRegex
-where
-    T: Into<String> + fmt::Display,
-{
-    HumanRegex(format!("(?:{}){{{},{}}}", target, n, m))
+pub fn between<T>(n: u8, m: u8, target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?:{}){{{},{}}}", target, n, m), pd::<SymbolChain>)
 }
 
 /// Match one or more of a certain target
@@ -34,11 +29,8 @@ where
 /// assert!(regex_string.to_regex().is_match("aaaa"));
 /// assert!(!regex_string.to_regex().is_match("bb"));
 /// ```
-pub fn one_or_more<T>(target: T) -> HumanRegex
-where
-    T: Into<String> + fmt::Display,
-{
-    HumanRegex(format!("(?:{})+", target))
+pub fn one_or_more<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?:{})+", target), pd::<SymbolChain>)
 }
 
 /// Match zero or more of a certain target
@@ -47,11 +39,8 @@ where
 /// assert!(regex_string.to_regex().is_match("a"));
 /// assert!(regex_string.to_regex().is_match("bb"));
 /// ```
-pub fn zero_or_more<T>(target: T) -> HumanRegex
-where
-    T: Into<String> + fmt::Display,
-{
-    HumanRegex(format!("(?:{})*", target))
+pub fn zero_or_more<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?:{})*", target), pd::<SymbolChain>)
 }
 
 /// Match zero or one of a certain target
@@ -60,11 +49,8 @@ where
 /// assert!(regex_string.to_regex().is_match("a"));
 /// assert!(regex_string.to_regex().is_match("bb"));
 /// ```
-pub fn zero_or_one<T>(target: T) -> HumanRegex
-where
-    T: Into<String> + fmt::Display,
-{
-    HumanRegex(format!("(?:{})?", target))
+pub fn zero_or_one<T>(target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?:{})?", target), pd::<SymbolChain>)
 }
 
 /// Match exactly _n_ of a certain target
@@ -73,9 +59,6 @@ where
 /// assert!(regex_string.to_regex().is_match("aaaaa"));
 /// assert!(!regex_string.to_regex().is_match("aaa"));
 /// ```
-pub fn exactly<T>(n: u8, target: T) -> HumanRegex
-where
-    T: Into<String> + fmt::Display,
-{
-    HumanRegex(format!("(?:{}){{{}}}", target, n))
+pub fn exactly<T>(n: u8, target: HumanRegex<T>) -> HumanRegex<SymbolChain> {
+    HumanRegex(format!("(?:{}){{{}}}", target, n), pd::<SymbolChain>)
 }

--- a/src/shorthand.rs
+++ b/src/shorthand.rs
@@ -1,6 +1,7 @@
 //! Functions for general purpose matches
 
-use super::humanregex::HumanRegex;
+use super::humanregex::*;
+use std::marker::PhantomData as pd;
 
 /// A function for matching any character (except for \n)
 /// ```
@@ -9,8 +10,8 @@ use super::humanregex::HumanRegex;
 /// assert!(regex_string.to_regex().is_match("hurl"));
 /// assert!(regex_string.to_regex().is_match("heal"));
 /// ```
-pub fn any() -> HumanRegex {
-    HumanRegex(r".".to_string())
+pub fn any() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r".".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// A function for the digit character class (i.e., the digits 0 through 9)
@@ -20,8 +21,8 @@ pub fn any() -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("010101010100100100100101"));
 /// assert!(!regex_string.to_regex().is_match("a string that is not composed of digits will fail"));
 /// ```
-pub fn digit() -> HumanRegex {
-    HumanRegex(r"\d".to_string())
+pub fn digit() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"\d".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// A function for the non-digit character class (i.e., everything BUT the digits 0-9)
@@ -31,18 +32,18 @@ pub fn digit() -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("a string without digits will pass"));
 /// assert!(!regex_string.to_regex().is_match("a string with digits like 99 will fail"));
 /// ```
-pub fn non_digit() -> HumanRegex {
-    HumanRegex(r"\D".to_string())
+pub fn non_digit() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"\D".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// A function for the word character class (i.e., all alphanumeric characters plus underscore)
-pub fn word() -> HumanRegex {
-    HumanRegex(r"\w".to_string())
+pub fn word() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"\w".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// A function for the non-word character class (i.e., everything BUT the alphanumeric characters plus underscore)
-pub fn non_word() -> HumanRegex {
-    HumanRegex(r"\W".to_string())
+pub fn non_word() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"\W".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// A constant for the whitespace character class (i.e., space and tab)
@@ -53,8 +54,8 @@ pub fn non_word() -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("at least"));
 /// assert!(regex_string.to_regex().is_match("at    least"));
 /// ```
-pub fn whitespace() -> HumanRegex {
-    HumanRegex(r"\s".to_string())
+pub fn whitespace() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"\s".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// A function for the whitespace character class (i.e., everything BUT space and tab)
@@ -65,8 +66,8 @@ pub fn whitespace() -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("a-sluggified-thingamajig"));
 /// assert!(!regex_string.to_regex().is_match("something with spaces won't pass"));
 /// ```
-pub fn non_whitespace() -> HumanRegex {
-    HumanRegex(r"\S".to_string())
+pub fn non_whitespace() -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(r"\S".to_string(), pd::<SymbolClass<Standard>>)
 }
 
 /// Matches anything within a range of characters
@@ -77,8 +78,11 @@ pub fn non_whitespace() -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("c"));
 /// assert!(!regex_string.to_regex().is_match("h"));
 ///```
-pub fn within(range: std::ops::RangeInclusive<char>) -> HumanRegex {
-    HumanRegex(format!("[{}-{}]", range.start(), range.end()))
+pub fn within_range(range: std::ops::RangeInclusive<char>) -> HumanRegex<SymbolClass<Custom>> {
+    HumanRegex(
+        format!("[{}-{}]", range.start(), range.end()),
+        pd::<SymbolClass<Custom>>,
+    )
 }
 /// Matches anything outside of a range of characters
 ///```
@@ -88,8 +92,25 @@ pub fn within(range: std::ops::RangeInclusive<char>) -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("h"));
 /// assert!(!regex_string.to_regex().is_match("c"));
 ///```
-pub fn without(range: std::ops::RangeInclusive<char>) -> HumanRegex {
-    HumanRegex(format!("[^{}-{}]", range.start(), range.end()))
+pub fn without_range(range: std::ops::RangeInclusive<char>) -> HumanRegex<SymbolClass<Custom>> {
+    HumanRegex(
+        format!("[^{}-{}]", range.start(), range.end()),
+        pd::<SymbolClass<Custom>>,
+    )
+}
+
+pub fn within_set<T>(set: &[T]) -> HumanRegex<SymbolClass<Custom>>
+where
+    [T]: Into<String> + fmt::Display,
+{
+    HumanRegex(format!("[{}]", set.to_string()), pd::<SymbolClass<Custom>>)
+}
+
+pub fn without_set<T>(set: &[T]) -> HumanRegex<SymbolClass<Custom>>
+where
+    [T]: Into<String> + fmt::Display,
+{
+    HumanRegex(format!("[^{}]", set.to_string()), pd::<SymbolClass<Custom>>)
 }
 
 /// An enum covering all Unicode character categories
@@ -146,47 +167,50 @@ pub enum UnicodeCategory {
 /// assert!(regex_string.to_regex().is_match("$¥₹"));
 /// assert!(!regex_string.to_regex().is_match("normal words"));
 /// ```
-pub fn unicode_category(category: UnicodeCategory) -> HumanRegex {
-    HumanRegex(match category {
-        UnicodeCategory::Letter => r"\p{Letter}".to_string(),
-        UnicodeCategory::LowercaseLetter => r"\p{Lowercase_Letter}".to_string(),
-        UnicodeCategory::UppercaseLetter => r"\p{Uppercase_Letter}".to_string(),
-        UnicodeCategory::TitlecaseLetter => r"\p{Titlecase_Letter}".to_string(),
-        UnicodeCategory::CasedLetter => r"\p{Cased_Letter}".to_string(),
-        UnicodeCategory::ModifierLetter => r"\p{Modifier_Letter}".to_string(),
-        UnicodeCategory::OtherLetter => r"\p{Other_Letter}".to_string(),
-        UnicodeCategory::Mark => r"\p{Mark}".to_string(),
-        UnicodeCategory::NonSpacingMark => r"\p{NonSpacing_Mark}".to_string(),
-        UnicodeCategory::SpaceCombiningMark => r"\p{SpaceCombining_Mark}".to_string(),
-        UnicodeCategory::EnclosingMark => r"\p{Enclosing_Mark}".to_string(),
-        UnicodeCategory::Separator => r"\p{Separator}".to_string(),
-        UnicodeCategory::SpaceSeparator => r"\p{Space_Separator}".to_string(),
-        UnicodeCategory::LineSeparator => r"\p{Line_Separator}".to_string(),
-        UnicodeCategory::ParagraphSeparator => r"\p{Paragraph_Separator}".to_string(),
-        UnicodeCategory::Symbol => r"\p{Symbol}".to_string(),
-        UnicodeCategory::MathSymbol => r"\p{Math_Symbol}".to_string(),
-        UnicodeCategory::CurrencySymbol => r"\p{Currency_Symbol}".to_string(),
-        UnicodeCategory::ModifierSymbol => r"\p{Modifier_Symbol}".to_string(),
-        UnicodeCategory::OtherSymbol => r"\p{Other_Symbol}".to_string(),
-        UnicodeCategory::Number => r"\p{Number}".to_string(),
-        UnicodeCategory::DecimalDigitNumber => r"\p{DecimalDigit_Number}".to_string(),
-        UnicodeCategory::LetterNumber => r"\p{Letter_Number}".to_string(),
-        UnicodeCategory::OtherNumber => r"\p{Other_Number}".to_string(),
-        UnicodeCategory::Punctuation => r"\p{Punctuation}".to_string(),
-        UnicodeCategory::DashPunctuation => r"\p{Dash_Punctuation}".to_string(),
-        UnicodeCategory::OpenPunctuation => r"\p{Open_Punctuation}".to_string(),
-        UnicodeCategory::ClosePunctuation => r"\p{Close_Punctuation}".to_string(),
-        UnicodeCategory::InitialPunctuation => r"\p{Initial_Punctuation}".to_string(),
-        UnicodeCategory::FinalPunctuation => r"\p{Final_Punctuation}".to_string(),
-        UnicodeCategory::ConnectorPunctuation => r"\p{Connector_Punctuation}".to_string(),
-        UnicodeCategory::OtherPunctuation => r"\p{Other_Punctuation}".to_string(),
-        UnicodeCategory::Other => r"\p{Other}".to_string(),
-        UnicodeCategory::Control => r"\p{Control}".to_string(),
-        UnicodeCategory::Format => r"\p{Format}".to_string(),
-        UnicodeCategory::PrivateUse => r"\p{Private_Use}".to_string(),
-        UnicodeCategory::Surrogate => r"\p{Surrogate}".to_string(),
-        UnicodeCategory::Unassigned => r"\p{Unassigned}".to_string(),
-    })
+pub fn unicode_category(category: UnicodeCategory) -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(
+        match category {
+            UnicodeCategory::Letter => r"\p{Letter}".to_string(),
+            UnicodeCategory::LowercaseLetter => r"\p{Lowercase_Letter}".to_string(),
+            UnicodeCategory::UppercaseLetter => r"\p{Uppercase_Letter}".to_string(),
+            UnicodeCategory::TitlecaseLetter => r"\p{Titlecase_Letter}".to_string(),
+            UnicodeCategory::CasedLetter => r"\p{Cased_Letter}".to_string(),
+            UnicodeCategory::ModifierLetter => r"\p{Modifier_Letter}".to_string(),
+            UnicodeCategory::OtherLetter => r"\p{Other_Letter}".to_string(),
+            UnicodeCategory::Mark => r"\p{Mark}".to_string(),
+            UnicodeCategory::NonSpacingMark => r"\p{NonSpacing_Mark}".to_string(),
+            UnicodeCategory::SpaceCombiningMark => r"\p{SpaceCombining_Mark}".to_string(),
+            UnicodeCategory::EnclosingMark => r"\p{Enclosing_Mark}".to_string(),
+            UnicodeCategory::Separator => r"\p{Separator}".to_string(),
+            UnicodeCategory::SpaceSeparator => r"\p{Space_Separator}".to_string(),
+            UnicodeCategory::LineSeparator => r"\p{Line_Separator}".to_string(),
+            UnicodeCategory::ParagraphSeparator => r"\p{Paragraph_Separator}".to_string(),
+            UnicodeCategory::Symbol => r"\p{Symbol}".to_string(),
+            UnicodeCategory::MathSymbol => r"\p{Math_Symbol}".to_string(),
+            UnicodeCategory::CurrencySymbol => r"\p{Currency_Symbol}".to_string(),
+            UnicodeCategory::ModifierSymbol => r"\p{Modifier_Symbol}".to_string(),
+            UnicodeCategory::OtherSymbol => r"\p{Other_Symbol}".to_string(),
+            UnicodeCategory::Number => r"\p{Number}".to_string(),
+            UnicodeCategory::DecimalDigitNumber => r"\p{DecimalDigit_Number}".to_string(),
+            UnicodeCategory::LetterNumber => r"\p{Letter_Number}".to_string(),
+            UnicodeCategory::OtherNumber => r"\p{Other_Number}".to_string(),
+            UnicodeCategory::Punctuation => r"\p{Punctuation}".to_string(),
+            UnicodeCategory::DashPunctuation => r"\p{Dash_Punctuation}".to_string(),
+            UnicodeCategory::OpenPunctuation => r"\p{Open_Punctuation}".to_string(),
+            UnicodeCategory::ClosePunctuation => r"\p{Close_Punctuation}".to_string(),
+            UnicodeCategory::InitialPunctuation => r"\p{Initial_Punctuation}".to_string(),
+            UnicodeCategory::FinalPunctuation => r"\p{Final_Punctuation}".to_string(),
+            UnicodeCategory::ConnectorPunctuation => r"\p{Connector_Punctuation}".to_string(),
+            UnicodeCategory::OtherPunctuation => r"\p{Other_Punctuation}".to_string(),
+            UnicodeCategory::Other => r"\p{Other}".to_string(),
+            UnicodeCategory::Control => r"\p{Control}".to_string(),
+            UnicodeCategory::Format => r"\p{Format}".to_string(),
+            UnicodeCategory::PrivateUse => r"\p{Private_Use}".to_string(),
+            UnicodeCategory::Surrogate => r"\p{Surrogate}".to_string(),
+            UnicodeCategory::Unassigned => r"\p{Unassigned}".to_string(),
+        },
+        pd::<SymbolClass<Standard>>,
+    )
 }
 
 /// A function for not matching Unicode character categories. For matching script categories see [non_unicode_script].
@@ -198,8 +222,8 @@ pub fn unicode_category(category: UnicodeCategory) -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("normal words"));
 /// assert!(!regex_string.to_regex().is_match("$¥₹"));
 /// ```
-pub fn non_unicode_category(category: UnicodeCategory) -> HumanRegex {
-    HumanRegex(unicode_category(category).to_string().replace(r"\p", r"\P"))
+pub fn non_unicode_category(category: UnicodeCategory) -> HumanRegex<SymbolClass<Standard>> {
+    !unicode_category(category)
 }
 
 /// An enum for covering all Unicode script categories
@@ -263,54 +287,57 @@ pub enum UnicodeScript {
 /// assert!(regex_string.to_regex().is_match("蟹"));
 /// assert!(!regex_string.to_regex().is_match("latin text"));
 /// ```
-pub fn unicode_script(category: UnicodeScript) -> HumanRegex {
-    HumanRegex(match category {
-        UnicodeScript::Common => r"\p{Common}".to_string(),
-        UnicodeScript::Arabic => r"\p{Arabic}".to_string(),
-        UnicodeScript::Armenian => r"\p{Armenian}".to_string(),
-        UnicodeScript::Bengali => r"\p{Bengali}".to_string(),
-        UnicodeScript::Bopomofo => r"\p{Bopomofo}".to_string(),
-        UnicodeScript::Braille => r"\p{Braille}".to_string(),
-        UnicodeScript::Buhid => r"\p{Buhid}".to_string(),
-        UnicodeScript::CandianAboriginal => r"\p{CandianAboriginal}".to_string(),
-        UnicodeScript::Cherokee => r"\p{Cherokee}".to_string(),
-        UnicodeScript::Cyrillic => r"\p{Cyrillic}".to_string(),
-        UnicodeScript::Devanagari => r"\p{Devanagari}".to_string(),
-        UnicodeScript::Ethiopic => r"\p{Ethiopic}".to_string(),
-        UnicodeScript::Georgian => r"\p{Georgian}".to_string(),
-        UnicodeScript::Greek => r"\p{Greek}".to_string(),
-        UnicodeScript::Gujarati => r"\p{Gujarati}".to_string(),
-        UnicodeScript::Gurkmukhi => r"\p{Gurkmukhi}".to_string(),
-        UnicodeScript::Han => r"\p{Han}".to_string(),
-        UnicodeScript::Hangul => r"\p{Hangul}".to_string(),
-        UnicodeScript::Hanunoo => r"\p{Hanunoo}".to_string(),
-        UnicodeScript::Hebrew => r"\p{Hebrew}".to_string(),
-        UnicodeScript::Hirigana => r"\p{Hirigana}".to_string(),
-        UnicodeScript::Inherited => r"\p{Inherited}".to_string(),
-        UnicodeScript::Kannada => r"\p{Kannada}".to_string(),
-        UnicodeScript::Katakana => r"\p{Katakana}".to_string(),
-        UnicodeScript::Khmer => r"\p{Khmer}".to_string(),
-        UnicodeScript::Lao => r"\p{Lao}".to_string(),
-        UnicodeScript::Latin => r"\p{Latin}".to_string(),
-        UnicodeScript::Limbu => r"\p{Limbu}".to_string(),
-        UnicodeScript::Malayalam => r"\p{Malayalam}".to_string(),
-        UnicodeScript::Mongolian => r"\p{Mongolian}".to_string(),
-        UnicodeScript::Myanmar => r"\p{Myanmar}".to_string(),
-        UnicodeScript::Ogham => r"\p{Ogham}".to_string(),
-        UnicodeScript::Oriya => r"\p{Oriya}".to_string(),
-        UnicodeScript::Runic => r"\p{Runic}".to_string(),
-        UnicodeScript::Sinhala => r"\p{Sinhala}".to_string(),
-        UnicodeScript::Syriac => r"\p{Syriac}".to_string(),
-        UnicodeScript::Tagalog => r"\p{Tagalog}".to_string(),
-        UnicodeScript::Tagbanwa => r"\p{Tagbanwa}".to_string(),
-        UnicodeScript::TaiLe => r"\p{TaiLe}".to_string(),
-        UnicodeScript::Tamil => r"\p{Tamil}".to_string(),
-        UnicodeScript::Telugu => r"\p{Telugu}".to_string(),
-        UnicodeScript::Thaana => r"\p{Thaana}".to_string(),
-        UnicodeScript::Thai => r"\p{Thai}".to_string(),
-        UnicodeScript::Tibetan => r"\p{Tibetan}".to_string(),
-        UnicodeScript::Yi => r"\p{Yi}".to_string(),
-    })
+pub fn unicode_script(category: UnicodeScript) -> HumanRegex<SymbolClass<Standard>> {
+    HumanRegex(
+        match category {
+            UnicodeScript::Common => r"\p{Common}".to_string(),
+            UnicodeScript::Arabic => r"\p{Arabic}".to_string(),
+            UnicodeScript::Armenian => r"\p{Armenian}".to_string(),
+            UnicodeScript::Bengali => r"\p{Bengali}".to_string(),
+            UnicodeScript::Bopomofo => r"\p{Bopomofo}".to_string(),
+            UnicodeScript::Braille => r"\p{Braille}".to_string(),
+            UnicodeScript::Buhid => r"\p{Buhid}".to_string(),
+            UnicodeScript::CandianAboriginal => r"\p{CandianAboriginal}".to_string(),
+            UnicodeScript::Cherokee => r"\p{Cherokee}".to_string(),
+            UnicodeScript::Cyrillic => r"\p{Cyrillic}".to_string(),
+            UnicodeScript::Devanagari => r"\p{Devanagari}".to_string(),
+            UnicodeScript::Ethiopic => r"\p{Ethiopic}".to_string(),
+            UnicodeScript::Georgian => r"\p{Georgian}".to_string(),
+            UnicodeScript::Greek => r"\p{Greek}".to_string(),
+            UnicodeScript::Gujarati => r"\p{Gujarati}".to_string(),
+            UnicodeScript::Gurkmukhi => r"\p{Gurkmukhi}".to_string(),
+            UnicodeScript::Han => r"\p{Han}".to_string(),
+            UnicodeScript::Hangul => r"\p{Hangul}".to_string(),
+            UnicodeScript::Hanunoo => r"\p{Hanunoo}".to_string(),
+            UnicodeScript::Hebrew => r"\p{Hebrew}".to_string(),
+            UnicodeScript::Hirigana => r"\p{Hirigana}".to_string(),
+            UnicodeScript::Inherited => r"\p{Inherited}".to_string(),
+            UnicodeScript::Kannada => r"\p{Kannada}".to_string(),
+            UnicodeScript::Katakana => r"\p{Katakana}".to_string(),
+            UnicodeScript::Khmer => r"\p{Khmer}".to_string(),
+            UnicodeScript::Lao => r"\p{Lao}".to_string(),
+            UnicodeScript::Latin => r"\p{Latin}".to_string(),
+            UnicodeScript::Limbu => r"\p{Limbu}".to_string(),
+            UnicodeScript::Malayalam => r"\p{Malayalam}".to_string(),
+            UnicodeScript::Mongolian => r"\p{Mongolian}".to_string(),
+            UnicodeScript::Myanmar => r"\p{Myanmar}".to_string(),
+            UnicodeScript::Ogham => r"\p{Ogham}".to_string(),
+            UnicodeScript::Oriya => r"\p{Oriya}".to_string(),
+            UnicodeScript::Runic => r"\p{Runic}".to_string(),
+            UnicodeScript::Sinhala => r"\p{Sinhala}".to_string(),
+            UnicodeScript::Syriac => r"\p{Syriac}".to_string(),
+            UnicodeScript::Tagalog => r"\p{Tagalog}".to_string(),
+            UnicodeScript::Tagbanwa => r"\p{Tagbanwa}".to_string(),
+            UnicodeScript::TaiLe => r"\p{TaiLe}".to_string(),
+            UnicodeScript::Tamil => r"\p{Tamil}".to_string(),
+            UnicodeScript::Telugu => r"\p{Telugu}".to_string(),
+            UnicodeScript::Thaana => r"\p{Thaana}".to_string(),
+            UnicodeScript::Thai => r"\p{Thai}".to_string(),
+            UnicodeScript::Tibetan => r"\p{Tibetan}".to_string(),
+            UnicodeScript::Yi => r"\p{Yi}".to_string(),
+        },
+        pd::<SymbolClass<Standard>>,
+    )
 }
 
 /// A function for matching Unicode characters not belonging to a certain script category. For matching other categories see [non_unicode_category].
@@ -322,6 +349,6 @@ pub fn unicode_script(category: UnicodeScript) -> HumanRegex {
 /// assert!(regex_string.to_regex().is_match("latin text"));
 /// assert!(!regex_string.to_regex().is_match("蟹"));
 /// ```
-pub fn non_unicode_script(category: UnicodeScript) -> HumanRegex {
-    HumanRegex(unicode_script(category).to_string().replace(r"\p", r"\P"))
+pub fn non_unicode_script(category: UnicodeScript) -> HumanRegex<SymbolClass<Standard>> {
+    !unicode_script(category)
 }

--- a/src/shorthand.rs
+++ b/src/shorthand.rs
@@ -72,9 +72,8 @@ pub fn non_whitespace() -> HumanRegex<SymbolClass<Standard>> {
 
 /// Matches anything within a range of characters
 ///```
-/// use human_regex::{beginning, end, within};
-/// let regex_string = beginning() + within('a'..='d') + end();
-/// println!("{}", beginning());
+/// use human_regex::{within_range};
+/// let regex_string = within_range('a'..='d');
 /// assert!(regex_string.to_regex().is_match("c"));
 /// assert!(!regex_string.to_regex().is_match("h"));
 ///```
@@ -86,9 +85,8 @@ pub fn within_range(range: std::ops::RangeInclusive<char>) -> HumanRegex<SymbolC
 }
 /// Matches anything outside of a range of characters
 ///```
-/// use human_regex::{beginning, end, without};
-/// let regex_string = beginning() + without('a'..='d') + end();
-/// println!("{}", beginning());
+/// use human_regex::{without_range};
+/// let regex_string = without_range('a'..='d');
 /// assert!(regex_string.to_regex().is_match("h"));
 /// assert!(!regex_string.to_regex().is_match("c"));
 ///```
@@ -99,18 +97,46 @@ pub fn without_range(range: std::ops::RangeInclusive<char>) -> HumanRegex<Symbol
     )
 }
 
+/// Matches anything within a specified set of characters
+/// ```
+/// use human_regex::{text,within_set};
+/// let regex_string = text("gr") + within_set(&['a','e']) + text("y");
+/// assert!(regex_string.to_regex().is_match("gray"));
+/// assert!(regex_string.to_regex().is_match("grey"));
+/// assert!(!regex_string.to_regex().is_match("groy"));
+/// ```
 pub fn within_set<T>(set: &[T]) -> HumanRegex<SymbolClass<Custom>>
 where
-    [T]: Into<String> + fmt::Display,
+    T: Into<String> + fmt::Display,
 {
-    HumanRegex(format!("[{}]", set.to_string()), pd::<SymbolClass<Custom>>)
+    HumanRegex(
+        format!(
+            "[{}]",
+            set.into_iter().map(|c| c.to_string()).collect::<String>()
+        ),
+        pd::<SymbolClass<Custom>>,
+    )
 }
 
+/// Matches anything outside a specified set of characters
+/// ```
+/// use human_regex::{text,without_set};
+/// let regex_string = text("gr") + without_set(&['a','e']) + text("y");
+/// assert!(regex_string.to_regex().is_match("groy"));
+/// assert!(!regex_string.to_regex().is_match("gray"));
+/// assert!(!regex_string.to_regex().is_match("grey"));
+/// ```
 pub fn without_set<T>(set: &[T]) -> HumanRegex<SymbolClass<Custom>>
 where
-    [T]: Into<String> + fmt::Display,
+    T: Into<String> + fmt::Display,
 {
-    HumanRegex(format!("[^{}]", set.to_string()), pd::<SymbolClass<Custom>>)
+    HumanRegex(
+        format!(
+            "[^{}]",
+            set.into_iter().map(|c| c.to_string()).collect::<String>()
+        ),
+        pd::<SymbolClass<Custom>>,
+    )
 }
 
 /// An enum covering all Unicode character categories
@@ -215,10 +241,8 @@ pub fn unicode_category(category: UnicodeCategory) -> HumanRegex<SymbolClass<Sta
 
 /// A function for not matching Unicode character categories. For matching script categories see [non_unicode_script].
 /// ```
-/// use human_regex::{beginning, end, one_or_more, non_unicode_category, UnicodeCategory};
-/// let regex_string = beginning()
-///     + one_or_more(non_unicode_category(UnicodeCategory::CurrencySymbol))
-///     + end();
+/// use human_regex::{one_or_more, non_unicode_category, UnicodeCategory};
+/// let regex_string =one_or_more(non_unicode_category(UnicodeCategory::CurrencySymbol));
 /// assert!(regex_string.to_regex().is_match("normal words"));
 /// assert!(!regex_string.to_regex().is_match("$¥₹"));
 /// ```
@@ -343,9 +367,7 @@ pub fn unicode_script(category: UnicodeScript) -> HumanRegex<SymbolClass<Standar
 /// A function for matching Unicode characters not belonging to a certain script category. For matching other categories see [non_unicode_category].
 /// ```
 /// use human_regex::{beginning, end, one_or_more, non_unicode_script, UnicodeScript};
-/// let regex_string = beginning()
-///     + one_or_more(non_unicode_script(UnicodeScript::Han))
-///     + end();
+/// let regex_string =one_or_more(non_unicode_script(UnicodeScript::Han));
 /// assert!(regex_string.to_regex().is_match("latin text"));
 /// assert!(!regex_string.to_regex().is_match("蟹"));
 /// ```


### PR DESCRIPTION
After a good deal of research and two full rewrites, the whole API is now type-safe and panic proof. Errors will guide users to correct regex syntax and ensure that even runtime-generated regex cannot crash. My first attempt (you can look at the other branch in my fork) was quite convoluted, involving conversion of HumanRegex into a trait and doing a lot of conversion between things. Not more than two hours after I finished getting it mostly working, youtube recommends me [this video](https://youtu.be/_ccDqRTx-JU) by Let's Get Rusty demonstrating an extremely elegant pattern for the _exact_ thing I was trying to do. While that was a bit of a bruh moment (_couldn't you have recommended me this a few hours ago?_), I could not deny how extremely elegant the zero-sized types solution was, so I refactored everything a second time (hence the branch name) to use the pattern.

Essentially, the way it works is by making HumanRegex take a generic associated unit struct. That way, between 'subtypes' of HumanRegex\<T\>, the only thing that needs to change is what type you pass to it's new second tuple parameter, a PhantomData\<T\>, which writes itself out of existence at compile time.

The new types are pretty obviously named, LiteralSymbolChain is a chain of literal text, SymbolChain is any arbitrary chain of symbols, SymbolClass\<T\> is any kind of character class which can be further specified by Standard (for things like `.` `\w`, etc.), Custom (for `[xyz]` and `[x-y]`) and Ascii (for things like `[[: alpha :]]`). This also allowed me to make a unified negation operator that users (and we) can use. The only type of HumanRegex it's not implemented for is SymbolChain, and this is something I may return to. Because regular languages are closed under complement, algorithms do exist to negate any arbitrary regular expression. I'll probably do some more studying on this and implement it at a later date if someone doesn't get to it before me.

One last thing I wanted to comment on is the stark implementation differences between `or()` and all of the other logical operations like `and()` and `xor()`. While this may seem strange at first, it is entirely necessary, as the union operation for regular languages is fundamentally different than the other operations which are typically lumped in as "logical operations". Union is one of the three axiomatic operations on regular languages (along with concatenation and Kleene star), so it works on any arbitrary regular expression. The other ones like `and()` and `xor()` are exclusively operations on classes for a _single symbol_, rather than any arbitrary chain of symbols like union. I'm also now realizing that I forgot to overload the BitOr operator to syntax sugar `or()`, so if someone could implement that (should be extremely quick) it would be much appreciated.

If I haven't screwed something up badly, this should be the last breaking update on this API!

